### PR TITLE
Feat/bid/jy

### DIFF
--- a/src/main/java/growup/spring/springserver/campaign/repository/CampaignRepository.java
+++ b/src/main/java/growup/spring/springserver/campaign/repository/CampaignRepository.java
@@ -3,6 +3,8 @@ package growup.spring.springserver.campaign.repository;
 import growup.spring.springserver.campaign.domain.Campaign;
 import growup.spring.springserver.login.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +17,7 @@ public interface CampaignRepository extends JpaRepository<Campaign,Long> {
 
     List<Campaign> findAllByMember(Member member);
 
+    @Query("SELECT c FROM Campaign c WHERE c.campaignId = :campaignId AND c.member.email = :email")
+    Optional<Campaign> findByCampaignIdANDEmail(@Param("campaignId") Long campaignID,
+                                                @Param("email") String email);
 }

--- a/src/main/java/growup/spring/springserver/campaign/service/CampaignService.java
+++ b/src/main/java/growup/spring/springserver/campaign/service/CampaignService.java
@@ -29,4 +29,10 @@ public class CampaignService {
         if(campaignList.isEmpty()) throw new CampaignNotFoundException();
         return campaignList.stream().map(TypeChangeCampaign::entityToResponseDto).toList();
     }
+
+    public Campaign getMyCampaign(Long campaignId,String email){
+        return campaignRepository.findByCampaignIdANDEmail(campaignId,email).orElseThrow(
+                CampaignNotFoundException::new
+        );
+    }
 }

--- a/src/main/java/growup/spring/springserver/exception/keywordBid/KeywordBidNotFound.java
+++ b/src/main/java/growup/spring/springserver/exception/keywordBid/KeywordBidNotFound.java
@@ -1,0 +1,12 @@
+package growup.spring.springserver.exception.keywordBid;
+
+import growup.spring.springserver.global.exception.ErrorCode;
+import growup.spring.springserver.global.exception.GrouException;
+
+public class KeywordBidNotFound extends GrouException {
+    private static final ErrorCode errorCode = ErrorCode.KEYWORDBID_NOT_FOUND;
+
+    public KeywordBidNotFound() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
+++ b/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
@@ -1,5 +1,7 @@
 package growup.spring.springserver.global.error;
 
+import growup.spring.springserver.exception.campaign.CampaignNotFoundException;
+import growup.spring.springserver.global.exception.GrouException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +33,18 @@ public class ExceptionHandlerAdvice {
         log.error("Handler UnsupportedOperationException message: {}", e.getMessage());
         return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getMessage());
     }
+
+    @ExceptionHandler(CampaignNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> campaignNotFoundException(CampaignNotFoundException e) {
+        log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
+        return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
+    }
+
+    @ExceptionHandler(GrouException.class)
+    public ResponseEntity<ErrorResponseDto> campaignNotFoundException(GrouException e) {
+        log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
+        return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
+    }
+
 }
 

--- a/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
+++ b/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
@@ -1,12 +1,15 @@
 package growup.spring.springserver.global.error;
 
+import growup.spring.springserver.exception.InvalidDateFormatException;
 import growup.spring.springserver.exception.campaign.CampaignNotFoundException;
 import growup.spring.springserver.global.exception.GrouException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Map;
@@ -42,6 +45,14 @@ public class ExceptionHandlerAdvice {
 
     @ExceptionHandler(GrouException.class)
     public ResponseEntity<ErrorResponseDto> campaignNotFoundException(GrouException e) {
+        log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
+        return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
+    }
+
+    // controller 에서 LocalDate Parm 형식 오류 시 던지는 에러
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> MethodArgumentTypeMismatchException() {
+        InvalidDateFormatException e = new InvalidDateFormatException();
         log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
         return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
     }

--- a/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
+++ b/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     //Global
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 이상합니다."),
 
+
+    //KeywordBid
+    KEYWORDBID_NOT_FOUND(HttpStatus.BAD_REQUEST,"입찰가 정보가 없습니다.")
     ;
 
 

--- a/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
+++ b/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
@@ -15,7 +15,7 @@ public class TypeChangeKeyword {
                 .keyCvr((double) (Math.round(keyword.getKeyCvr()*100)/100))
                 .keyImpressions(keyword.getKeyImpressions())
                 .keyRoas((double) (Math.round(keyword.getKeyRoas()*100)/100))
-                .keyDate(keyword.getKeyDate())
+                .keyDate(keyword.getKeyDate().toString())
                 .keyExcludeFlag(false)
                 .keySearchType(keyword.getKeySearchType())
                 .keyTotalSales(keyword.getKeyTotalSales())

--- a/src/main/java/growup/spring/springserver/keyword/controller/KeywordController.java
+++ b/src/main/java/growup/spring/springserver/keyword/controller/KeywordController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RequestMapping("/api/keyword")
@@ -21,8 +22,8 @@ public class KeywordController {
     private KeywordService keywordService;
 
     @GetMapping("/getKeywordsAboutCampaign")
-    public ResponseEntity<CommonResponse<?>> getKeywordAboutCampaign(@RequestParam("start") String start,
-                                                                     @RequestParam("end") String end,
+    public ResponseEntity<CommonResponse<?>> getKeywordAboutCampaign(@RequestParam("start") LocalDate start,
+                                                                     @RequestParam("end") LocalDate end,
                                                                      @RequestParam("campaignId") Long campaignId,
                                                                      @AuthenticationPrincipal UserDetails userDetails){
         log.info("start getKeywordAboutCampaign target "+ userDetails.getUsername());

--- a/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
+++ b/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
@@ -1,5 +1,6 @@
 package growup.spring.springserver.keyword.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import growup.spring.springserver.keyword.domain.Keyword;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,7 @@ import java.time.LocalDate;
 
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class KeywordResponseDto {
 
     private String keyKeyword;  // 키워드
@@ -30,11 +32,13 @@ public class KeywordResponseDto {
 
     private Double keyRoas ;  // ROAS
 
-    private LocalDate keyDate;  // 날짜
+    private String keyDate;  // 날짜
 
     private Boolean keyExcludeFlag = false;  // 제외여부
 
     private String keySearchType;// 검색 비검색
+
+    private Long bid;
 
     public void update(Keyword keyword){
         keyClicks += keyword.getKeyClicks();

--- a/src/main/java/growup/spring/springserver/keyword/repository/KeywordRepository.java
+++ b/src/main/java/growup/spring/springserver/keyword/repository/KeywordRepository.java
@@ -18,4 +18,13 @@ public interface KeywordRepository extends JpaRepository <Keyword,Long>{
     List<Keyword> findAllByDateANDCampaign(@Param("startDate") LocalDate startDate,
                                            @Param("endDate")LocalDate endDate,
                                            @Param("campaignId")Long campaignId);
+
+    @Query("SELECT k FROM Keyword k WHERE k.keyDate BETWEEN :start AND :end " +
+            "AND k.campaign.campaignId = :campaignId " +
+            "AND k.keyKeyword IN :keys")
+    List<Keyword> findKeywordsByDateAndCampaignIdAndKeys(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end,
+            @Param("campaignId") Long campaignId,
+            @Param("keys") List<String> keys);
 }

--- a/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
+++ b/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
@@ -28,35 +28,11 @@ public class KeywordService {
     @Autowired
     private ExclusionKeywordService exclusionKeywordService;
     public List<KeywordResponseDto> getKeywordsByCampaignId(String start, String end , Long campaignId){
-        LocalDate startDate;
-        LocalDate endDate;
-        try{
-            startDate = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
-            endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
-            if(startDate.isAfter(endDate)) throw new DataFormatException();
-        }catch (DateTimeParseException | DataFormatException e){
-            throw new InvalidDateFormatException();
-        }
+        if(!checkDateFormat(start,end)) throw new InvalidDateFormatException();
+        LocalDate startDate  = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
+        LocalDate endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
         List<Keyword> data = keywordRepository.findAllByDateANDCampaign(startDate,endDate,campaignId);
-        if(data.isEmpty()) throw new CampaignKeywordNotFoundException();
-        HashMap<String,KeywordResponseDto> map = new HashMap<>();
-        for(Keyword keyword : data){
-            if(keyword.getKeyKeyword() == null || keyword.getKeyKeyword().isEmpty()){
-                continue;
-            }
-            if(map.containsKey(keyword.getKeyKeyword())){
-                map.get(keyword.getKeyKeyword()).update(keyword);
-                continue;
-            }
-            map.put(keyword.getKeyKeyword(),TypeChangeKeyword.entityToResponseDto(keyword));
-        }
-        List<KeywordResponseDto> keywordResponseDtos = new ArrayList<>();
-        Set<String> exclusions = getExclusionKeywordToSet(campaignId);
-        for(String key : map.keySet()){
-            if(!exclusions.isEmpty() &&exclusions.contains(key)) map.get(key).setKeyExcludeFlag(true);
-            keywordResponseDtos.add(map.get(key));
-        }
-        return keywordResponseDtos;
+        return checkKeyType(summeryKeywordData(data),getExclusionKeywordToSet(campaignId));
     }
 
     public Set<String> getExclusionKeywordToSet(Long campaignId){
@@ -69,5 +45,43 @@ public class KeywordService {
         return exclusionKeywordResponseDtos.stream()
                 .map(ExclusionKeywordResponseDto::getExclusionKeyword)
                 .collect(Collectors.toSet());
+    }
+
+    public boolean checkDateFormat(String start , String end){
+        LocalDate startDate;
+        LocalDate endDate;
+        try{
+            startDate = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
+            endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
+            if(startDate.isAfter(endDate)) throw new DataFormatException();
+        }catch (DateTimeParseException | DataFormatException e){
+           return false;
+        }
+        return true;
+    }
+
+    public HashMap<String,KeywordResponseDto> summeryKeywordData(List<Keyword> data){
+        if(data.isEmpty()) throw new CampaignKeywordNotFoundException();
+        HashMap<String,KeywordResponseDto> map = new HashMap<>();
+        for(Keyword keyword : data){
+            if(keyword.getKeyKeyword() == null || keyword.getKeyKeyword().isEmpty()){
+                continue;
+            }
+            if(map.containsKey(keyword.getKeyKeyword())){
+                map.get(keyword.getKeyKeyword()).update(keyword);
+                continue;
+            }
+            map.put(keyword.getKeyKeyword(),TypeChangeKeyword.entityToResponseDto(keyword));
+        }
+        return map;
+    }
+
+    public List<KeywordResponseDto> checkKeyType(HashMap<String,KeywordResponseDto> map,Set<String> exclusions){
+        List<KeywordResponseDto> keywordResponseDtos = new ArrayList<>();
+        for(String key : map.keySet()){
+            if(!exclusions.isEmpty() &&exclusions.contains(key)) map.get(key).setKeyExcludeFlag(true);
+            keywordResponseDtos.add(map.get(key));
+        }
+        return keywordResponseDtos;
     }
 }

--- a/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
+++ b/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
@@ -8,16 +8,14 @@ import growup.spring.springserver.keyword.domain.Keyword;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;
 import growup.spring.springserver.keyword.TypeChangeKeyword;
 import growup.spring.springserver.keyword.repository.KeywordRepository;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.DataFormatException;
 
@@ -83,5 +81,26 @@ public class KeywordService {
             keywordResponseDtos.add(map.get(key));
         }
         return keywordResponseDtos;
+    }
+
+    public List<KeywordResponseDto> addBids(HashMap<String,KeywordResponseDto> map,List<KeywordBidDto> keys){
+        List<KeywordResponseDto> keywordResponseDtos = new ArrayList<>();
+        for(KeywordBidDto dto : keys){
+            map.get(dto.getKeyword()).setBid(dto.getBid());
+            keywordResponseDtos.add(map.get(dto.getKeyword()));
+        }
+        return keywordResponseDtos;
+    }
+
+    public List<KeywordResponseDto> getKeywordsByDateAndCampaignIdAndKeys(String start,
+                                                                          String end,
+                                                                          Long campaignId,
+                                                                          List<KeywordBidDto> keys){
+        if(!checkDateFormat(start,end)) throw new InvalidDateFormatException();
+        LocalDate startDate  = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
+        LocalDate endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
+        List<Keyword> data =
+                keywordRepository.findKeywordsByDateAndCampaignIdAndKeys(startDate,endDate,campaignId,keys.stream().map(KeywordBidDto::getKeyword).toList());
+        return addBids(summeryKeywordData(data),keys);
     }
 }

--- a/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
+++ b/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
@@ -25,11 +25,9 @@ public class KeywordService {
     private KeywordRepository keywordRepository;
     @Autowired
     private ExclusionKeywordService exclusionKeywordService;
-    public List<KeywordResponseDto> getKeywordsByCampaignId(String start, String end , Long campaignId){
+    public List<KeywordResponseDto> getKeywordsByCampaignId(LocalDate start, LocalDate end , Long campaignId){
         if(!checkDateFormat(start,end)) throw new InvalidDateFormatException();
-        LocalDate startDate  = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
-        LocalDate endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
-        List<Keyword> data = keywordRepository.findAllByDateANDCampaign(startDate,endDate,campaignId);
+        List<Keyword> data = keywordRepository.findAllByDateANDCampaign(start,end,campaignId);
         return checkKeyType(summeryKeywordData(data),getExclusionKeywordToSet(campaignId));
     }
 
@@ -45,13 +43,9 @@ public class KeywordService {
                 .collect(Collectors.toSet());
     }
 
-    public boolean checkDateFormat(String start , String end){
-        LocalDate startDate;
-        LocalDate endDate;
+    public boolean checkDateFormat(LocalDate start , LocalDate end){
         try{
-            startDate = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
-            endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
-            if(startDate.isAfter(endDate)) throw new DataFormatException();
+            if(start.isAfter(end)) throw new DataFormatException();
         }catch (DateTimeParseException | DataFormatException e){
            return false;
         }
@@ -92,15 +86,13 @@ public class KeywordService {
         return keywordResponseDtos;
     }
 
-    public List<KeywordResponseDto> getKeywordsByDateAndCampaignIdAndKeys(String start,
-                                                                          String end,
+    public List<KeywordResponseDto> getKeywordsByDateAndCampaignIdAndKeys(LocalDate start,
+                                                                          LocalDate end,
                                                                           Long campaignId,
                                                                           List<KeywordBidDto> keys){
         if(!checkDateFormat(start,end)) throw new InvalidDateFormatException();
-        LocalDate startDate  = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
-        LocalDate endDate = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
         List<Keyword> data =
-                keywordRepository.findKeywordsByDateAndCampaignIdAndKeys(startDate,endDate,campaignId,keys.stream().map(KeywordBidDto::getKeyword).toList());
+                keywordRepository.findKeywordsByDateAndCampaignIdAndKeys(start,end,campaignId,keys.stream().map(KeywordBidDto::getKeyword).toList());
         return addBids(summeryKeywordData(data),keys);
     }
 }

--- a/src/main/java/growup/spring/springserver/keywordBid/KeywordBidController.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/KeywordBidController.java
@@ -1,0 +1,76 @@
+package growup.spring.springserver.keywordBid;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.campaign.service.CampaignService;
+import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordResponseDto;
+import growup.spring.springserver.global.common.CommonResponse;
+import growup.spring.springserver.keyword.dto.KeywordResponseDto;
+import growup.spring.springserver.keyword.service.KeywordService;
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidRequestDtos;
+import growup.spring.springserver.keywordBid.dto.KeywordBidResponseDto;
+import growup.spring.springserver.keywordBid.service.KeywordBidService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bid")
+public class KeywordBidController {
+
+    @Autowired
+    private KeywordBidService keywordBidService;
+    @Autowired
+    private CampaignService campaignService;
+    @Autowired
+    private KeywordService keywordService;
+
+    @PostMapping("/adds")
+    public ResponseEntity<CommonResponse<KeywordBidResponseDto>> addKeywordBid(@AuthenticationPrincipal UserDetails userDetails,
+                                                           @RequestBody @Valid KeywordBidRequestDtos keywordBidRequestDtos){
+        Campaign campaign = campaignService.getMyCampaign(keywordBidRequestDtos.getCampaignId(), userDetails.getUsername());
+        final KeywordBidResponseDto result = keywordBidService.addKeywordBids(keywordBidRequestDtos,campaign);
+        return new ResponseEntity<>(CommonResponse
+                .<KeywordBidResponseDto>builder("add bid data")
+                .data(result)
+                .build(), HttpStatus.OK);
+    }
+
+    @GetMapping("/gets")
+    public ResponseEntity<CommonResponse<List<KeywordResponseDto>>> getKeywordBids(@RequestParam("start") String start,
+                                                                     @RequestParam("end") String end,
+                                                                     @RequestParam("campaignId") Long campaignId,
+                                                                     @AuthenticationPrincipal UserDetails userDetails){
+        KeywordBidResponseDto result = keywordBidService.getKeywordBids(campaignId);
+        List<KeywordResponseDto> data = keywordService.getKeywordsByDateAndCampaignIdAndKeys(start,end,campaignId,result.getResponse());
+        return new ResponseEntity<>(CommonResponse
+                .<List<KeywordResponseDto>>builder("get bids")
+                .data(data)
+                .build(), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<CommonResponse<KeywordBidResponseDto>> deleteKeywordBid(@RequestBody @Valid KeywordBidRequestDtos keywordBidRequestDtos){
+        final KeywordBidResponseDto result = keywordBidService.deleteByCampaignIdAndKeyword(keywordBidRequestDtos);
+        return new ResponseEntity<>(CommonResponse
+                .<KeywordBidResponseDto>builder("delete bid data")
+                .data(result)
+                .build(), HttpStatus.OK);
+    }
+
+    @PatchMapping("/update")
+    public ResponseEntity<CommonResponse<KeywordBidResponseDto>> updateKeywordBid(@RequestBody @Valid KeywordBidRequestDtos keywordBidRequestDtos){
+        final KeywordBidResponseDto result = keywordBidService.updateKeywordBids(keywordBidRequestDtos);
+        return new ResponseEntity<>(CommonResponse
+                .<KeywordBidResponseDto>builder("update bid data")
+                .data(result)
+                .build(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/KeywordBidController.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/KeywordBidController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -44,8 +45,8 @@ public class KeywordBidController {
     }
 
     @GetMapping("/gets")
-    public ResponseEntity<CommonResponse<List<KeywordResponseDto>>> getKeywordBids(@RequestParam("start") String start,
-                                                                     @RequestParam("end") String end,
+    public ResponseEntity<CommonResponse<List<KeywordResponseDto>>> getKeywordBids(@RequestParam("start") LocalDate start,
+                                                                     @RequestParam("end") LocalDate end,
                                                                      @RequestParam("campaignId") Long campaignId,
                                                                      @AuthenticationPrincipal UserDetails userDetails){
         KeywordBidResponseDto result = keywordBidService.getKeywordBids(campaignId);

--- a/src/main/java/growup/spring/springserver/keywordBid/TypeChangeKeywordBid.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/TypeChangeKeywordBid.java
@@ -1,0 +1,13 @@
+package growup.spring.springserver.keywordBid;
+
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+
+public class TypeChangeKeywordBid {
+    public static KeywordBidDto entityToDto(KeywordBid keywordBid){
+        return KeywordBidDto.builder()
+                .keyword(keywordBid.getKeyword())
+                .bid(keywordBid.getBid())
+                .build();
+    }
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/domain/KeywordBid.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/domain/KeywordBid.java
@@ -1,0 +1,27 @@
+package growup.spring.springserver.keywordBid.domain;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Entity
+@Getter
+public class KeywordBid {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String keyword;
+
+    private Long bid;
+
+    @ManyToOne
+    @JoinColumn(name = "campaignId",referencedColumnName = "campaignId")
+    private Campaign campaign;
+
+    public void updateBid(Long bid){
+        this.bid = bid;
+    }
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidDto.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidDto.java
@@ -1,0 +1,13 @@
+package growup.spring.springserver.keywordBid.dto;
+
+import growup.spring.springserver.keyword.dto.KeywordResponseDto;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class KeywordBidDto {
+    private String keyword;
+    private Long bid;
+    private KeywordResponseDto keyInfo;
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidRequestDtos.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidRequestDtos.java
@@ -1,0 +1,18 @@
+package growup.spring.springserver.keywordBid.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class KeywordBidRequestDtos {
+    @NotNull(message = "캠패인 ID를 입력해주세요")
+    private Long campaignId;
+
+    @Size(min = 1, message = "요청 입찰가는 최소 1개 이상이어야 합니다.")
+    private List<KeywordBidDto> data;
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidResponseDto.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/dto/KeywordBidResponseDto.java
@@ -1,0 +1,20 @@
+package growup.spring.springserver.keywordBid.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KeywordBidResponseDto {
+    private int requestNumber;
+    private int responseNumber;
+    private List<KeywordBidDto> response;
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/repository/KeywordBidRepository.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/repository/KeywordBidRepository.java
@@ -1,0 +1,26 @@
+package growup.spring.springserver.keywordBid.repository;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KeywordBidRepository extends JpaRepository<KeywordBid,Long> {
+
+    @Query("SELECT k FROM KeywordBid k WHERE k.keyword = :keyword " +
+            "AND k.campaign.campaignId = :campaignId")
+    Optional<KeywordBid> findByCampaign_CampaignIdANDKeyword(@Param("campaignId") Long campaignId,
+                                                             @Param("keyword") String keyword);
+    @Modifying
+    @Query("DELETE FROM KeywordBid k WHERE k.campaign.campaignId = :campaignId AND k.keyword = :keyword")
+    int deleteByCampaign_CampaignIdANDKeyword(@Param("campaignId") Long campaignId,
+                                              @Param("keyword") String exclusionKeyword);
+
+    boolean existsByCampaign_CampaignIdAndKeyword(Long campaignId, String keyword);
+    List<KeywordBid> findAllByCampaign_CampaignId(Long campaignId);
+}

--- a/src/main/java/growup/spring/springserver/keywordBid/service/KeywordBidService.java
+++ b/src/main/java/growup/spring/springserver/keywordBid/service/KeywordBidService.java
@@ -1,0 +1,100 @@
+package growup.spring.springserver.keywordBid.service;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.campaign.service.CampaignService;
+import growup.spring.springserver.exception.keywordBid.KeywordBidNotFound;
+import growup.spring.springserver.keywordBid.TypeChangeKeywordBid;
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidRequestDtos;
+import growup.spring.springserver.keywordBid.dto.KeywordBidResponseDto;
+import growup.spring.springserver.keywordBid.repository.KeywordBidRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class KeywordBidService {
+    @Autowired
+    private CampaignService campaignService;
+    @Autowired
+    private KeywordBidRepository keywordBidRepository;
+
+    //여기서 CampaignService를 호출하는 것 보다, Controller 단에서 호출된 결과를 파라미터로 넣어주는건 어떨까
+    public KeywordBidResponseDto addKeywordBids(KeywordBidRequestDtos requests,Campaign campaign){
+        int requestDataSize = requests.getData().size();
+        List<KeywordBid> list = checkOverlapKeywordBid(requests.getData(),campaign);
+        int saveDataSize = list.size();
+        keywordBidRepository.saveAll(list);
+        return KeywordBidResponseDto.builder()
+                .requestNumber(requestDataSize)
+                .responseNumber(saveDataSize)
+                .build();
+    }
+
+    public List<KeywordBid> checkOverlapKeywordBid(List<KeywordBidDto> keywordBidDtos, Campaign campaign){
+        List<KeywordBid> list = new ArrayList<>();
+        for(KeywordBidDto dto : keywordBidDtos){
+            if(keywordBidRepository.existsByCampaign_CampaignIdAndKeyword(campaign.getCampaignId(),dto.getKeyword())) continue;
+            list.add(KeywordBid.builder()
+                    .keyword(dto.getKeyword())
+                    .campaign(campaign)
+                    .bid(dto.getBid())
+                    .build()
+            );
+        }
+        return list;
+    }
+
+    public KeywordBidResponseDto getKeywordBids(Long campaignId){
+        List<KeywordBid> list =  keywordBidRepository.findAllByCampaign_CampaignId(campaignId);
+        KeywordBidResponseDto keywordBidResponseDto = new KeywordBidResponseDto();
+        keywordBidResponseDto.setResponse(list.stream().map(TypeChangeKeywordBid::entityToDto).toList());
+        return keywordBidResponseDto;
+    }
+
+    @Transactional
+    public KeywordBidResponseDto updateKeywordBids(KeywordBidRequestDtos request){
+        int requestNumber = request.getData().size();
+        int updateNumber = requestNumber;
+        List<KeywordBidDto> list = new ArrayList<>();
+        for(KeywordBidDto data :request.getData()){
+            try {
+                KeywordBid nowData = findKeywordBidByCampaignIDAndKey(request.getCampaignId(), data.getKeyword());
+                nowData.updateBid(data.getBid());
+                list.add(TypeChangeKeywordBid.entityToDto(nowData));
+            }catch (KeywordBidNotFound error){
+                // 여러개의 update 값 중 하나를 찾지 못한 경우 로직이 계속 진행되도록 하고 싶었습니다.
+                updateNumber --;
+            }
+        }
+        // update 된 데이터의 수를 보내서 화면에 보여줄 계획입니다.
+        return KeywordBidResponseDto.builder()
+                .requestNumber(requestNumber)
+                .response(list)
+                .responseNumber(updateNumber)
+                .build();
+    }
+
+    public KeywordBid findKeywordBidByCampaignIDAndKey(Long campaignId, String key){
+        return keywordBidRepository.findByCampaign_CampaignIdANDKeyword(campaignId,key).orElseThrow(
+                KeywordBidNotFound::new
+        );
+    }
+
+    @Transactional
+    public KeywordBidResponseDto deleteByCampaignIdAndKeyword(KeywordBidRequestDtos request){
+        int requestNumber = request.getData().size();
+        int deleteNumber = 0;
+        for(KeywordBidDto data : request.getData()){
+            deleteNumber += keywordBidRepository.deleteByCampaign_CampaignIdANDKeyword(request.getCampaignId(),data.getKeyword());
+        }
+        return KeywordBidResponseDto.builder()
+                .requestNumber(requestNumber)
+                .responseNumber(deleteNumber)
+                .build();
+    }
+}

--- a/src/test/java/growup/spring/springserver/campaign/CampaignRepoTest.java
+++ b/src/test/java/growup/spring/springserver/campaign/CampaignRepoTest.java
@@ -5,6 +5,7 @@ import growup.spring.springserver.campaign.repository.CampaignRepository;
 import growup.spring.springserver.login.domain.Member;
 import growup.spring.springserver.login.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -67,6 +68,18 @@ public class CampaignRepoTest {
         final List<Campaign> data = campaignRepository.findAllByMember(member);
         //then
         assertThat(data.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("findByCampaignIdANDEmail() : Success. 캠패인 단건 조회")
+    void test3(){
+        //given
+        final Campaign input1 = newCampaign(member,"test1",1L);
+        campaignRepository.save(input1);
+        //whne
+        final Campaign result = campaignRepository.findByCampaignIdANDEmail(1L,member.getEmail()).get();
+        //then
+        assertThat(result.getCampaignId()).isEqualTo(1L);
     }
 
 

--- a/src/test/java/growup/spring/springserver/campaign/CampaignServiceTest.java
+++ b/src/test/java/growup/spring/springserver/campaign/CampaignServiceTest.java
@@ -6,6 +6,7 @@ import growup.spring.springserver.campaign.repository.CampaignRepository;
 import growup.spring.springserver.campaign.service.CampaignService;
 import growup.spring.springserver.exception.campaign.CampaignNotFoundException;
 import growup.spring.springserver.exception.login.MemberNotFoundException;
+import growup.spring.springserver.global.exception.ErrorCode;
 import growup.spring.springserver.login.domain.Member;
 import growup.spring.springserver.login.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static growup.spring.springserver.keywordBid.service.KeywordBidServiceTest.getCampaign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,6 +82,32 @@ class CampaignServiceTest {
         assertThat(result.get(0).getCampaignId()).isEqualTo(1L);
         assertThat(result.get(1).getCampaignId()).isEqualTo(2L);
         assertThat(result.get(2).getCampaignId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("getMyCampaign() : Error 캠패인 단건 조회 실패")
+    void test4_1(){
+        //given
+        doReturn(Optional.empty()).when(campaignRepository).findByCampaignIdANDEmail(1L,"test@test.com");
+        //when
+        CampaignNotFoundException result = assertThrows(CampaignNotFoundException.class,
+                ()-> campaignService.getMyCampaign(1L,"test@test.com"));
+        //then
+        assertThat(result.getErrorCode()).isEqualTo(ErrorCode.CAMPAIGN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getMyCampaign() : success 캠패인 단건 조회")
+    void test4(){
+        //given
+        doReturn(Optional.of(getCampaign())).when(campaignRepository).findByCampaignIdANDEmail(1L,"test@test.com");
+        //when
+        Campaign result = campaignService.getMyCampaign(1L,"test@test.com");
+        //then
+        assertThat(result.getCampaignId()).isEqualTo(1L);
+    }
+    public static Campaign getCampaign(){
+        return Campaign.builder().campaignId(1L).camCampaignName("testCamp").build();
     }
 
     public Member getMember(){

--- a/src/test/java/growup/spring/springserver/keyword/controller/KeywordControllerTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/controller/KeywordControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.Mockito.doReturn;
@@ -48,15 +49,27 @@ public class KeywordControllerTest {
     }
 
     @Test
+    @DisplayName("getKeywordsAboutCampaign: Error 2.LocalDate 형식이 이상할 떄")
+    @WithAuthUser
+    void test1_2() throws Exception {
+        final String url = "/api/keyword/getKeywordsAboutCampaign?start=2024-12-01&end=20-11-01&campaignId=1";
+        final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
+                .get(url));
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("getKeywordsAboutCampaign: Success 1.정상 요청")
     @WithAuthUser
     void test2() throws Exception {
         //when
         final String url = "/api/keyword/getKeywordsAboutCampaign?start=2024-12-01&end=2024-12-31&campaignId=1";
+        final LocalDate start = LocalDate.of(2024,12,1);
+        final LocalDate end = LocalDate.of(2024,12,31);
         doReturn(List.of(
                 getKeywordResDto(),
                 getKeywordResDto(),
-                getKeywordResDto())).when(keywordService).getKeywordsByCampaignId("2024-12-01","2024-12-31",1L);
+                getKeywordResDto())).when(keywordService).getKeywordsByCampaignId(start,end,1L);
         //given
         final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
                 .get(url));

--- a/src/test/java/growup/spring/springserver/keyword/repository/KeywordRepositoryTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/repository/KeywordRepositoryTest.java
@@ -49,7 +49,7 @@ public class KeywordRepositoryTest{
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @DisplayName("findAllByDateANDFlag() : Success 3. About Date ")
+    @DisplayName("findAllByDateANDFlag() : Success 2. About Date ")
     @Test
     void test6(){
         //when
@@ -64,6 +64,26 @@ public class KeywordRepositoryTest{
         List<Keyword> result = keywordRepository.findAllByDateANDCampaign(start,end,1L);
         //then
         assertThat(result.size()).isEqualTo(3);
+    }
+
+    @DisplayName("findKeywordsByDateAndCampaignIdAndKeys(): Success")
+    @Test
+    void test7(){
+        //when
+        LocalDate inDataDate = LocalDate.parse("2024-12-25",DateTimeFormatter.ISO_DATE);
+        LocalDate inDataDate2 = LocalDate.parse("2024-12-26",DateTimeFormatter.ISO_DATE);
+        LocalDate outDataDate = LocalDate.parse("2026-12-25",DateTimeFormatter.ISO_DATE);
+        keywordRepository.save(getKeyword("title1",campaign,inDataDate,false));
+        keywordRepository.save(getKeyword("title1",campaign,inDataDate2,false));
+        keywordRepository.save(getKeyword("title1",campaign,outDataDate,false));
+        keywordRepository.save(getKeyword("title2",campaign,inDataDate,false));
+        keywordRepository.save(getKeyword("title3",campaign,inDataDate,false));
+        keywordRepository.save(getKeyword("title4",campaign,outDataDate,false));
+        List<String> keys = List.of("title1","title2","title4");
+        //given
+        List<Keyword> result = keywordRepository.findKeywordsByDateAndCampaignIdAndKeys(start,end,1L,keys);
+        //then
+        assertThat(result).hasSize(3);
     }
 
     public Keyword getKeyword(String title, Campaign campaign){

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -41,8 +41,8 @@ public class KeywordServiceTest {
     @DisplayName("getKeyWords(): Success")
     void test1_7(){
         //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
+        final LocalDate start = LocalDate.of(2024,12,14);
+        final LocalDate end = LocalDate.of(2025,1,14);
         doReturn(List.of(getKeyword("exKey1",660.0,0.0,10L,123L,2L,11000.0)
                 ,getKeyword("exKey2",660.0,0.0,10L,123L,4L,0.0)
                 ,getKeyword("exKey3",660.0,0.0,112L,123L,34L,0.0)))
@@ -66,21 +66,8 @@ public class KeywordServiceTest {
     @DisplayName("checkDateFormat(): Error 1. 조회 시작날과 끝의 순서가 이상할 때")
     void test2_1(){
         //when
-        final String start = "2024-12-14";
-        final String end = "2023-12-14";
-        //given
-        final boolean result  = keywordService.checkDateFormat(start,end);
-        //then
-        assertThat(result).isFalse();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"20-10-11","2024-1-1","2024-01-1","2024-01-10-17"})
-    @DisplayName("checkDateFormat(): Error 2. LocalDate 형식 오류")
-    void test2_2(String wrongDataFormat){
-        //when
-        final String start = wrongDataFormat;
-        final String end = "2023-12-14";
+        final LocalDate start = LocalDate.of(2024,12,14);
+        final LocalDate end = LocalDate.of(2023,1,14);
         //given
         final boolean result  = keywordService.checkDateFormat(start,end);
         //then
@@ -89,10 +76,10 @@ public class KeywordServiceTest {
 
     @Test
     @DisplayName("checkDateFormat(): Success")
-    void test2_3(){
+    void test2_2(){
         //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
+        final LocalDate start = LocalDate.of(2024,12,14);
+        final LocalDate end = LocalDate.of(2025,1,14);
         //given
         final boolean result  = keywordService.checkDateFormat(start,end);
         //then
@@ -250,8 +237,8 @@ public class KeywordServiceTest {
                         ,getKeyword("k2",0.0,0.0,0L,0L,0L,0.0)
                         ,getKeyword("k3",0.0,0.0,0L,0L,0L,0.0)))
                 .when(keywordRepository).findKeywordsByDateAndCampaignIdAndKeys(any(LocalDate.class),any(LocalDate.class),any(Long.class),any(List.class));
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
+        final LocalDate start = LocalDate.of(2024,12,14);
+        final LocalDate end = LocalDate.of(2025,1,14);
         List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidRequestDto("k1",1L),
                 getKeywordBidRequestDto("k2",2L),
                 getKeywordBidRequestDto("k3",3L));

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -17,12 +17,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
@@ -37,137 +40,8 @@ public class KeywordServiceTest {
     private KeywordService keywordService;
 
     @Test
-    @DisplayName("getKeyWords(): Error 1. 해당 조건 데이터 없음")
-    void test1_1(){
-        //when
-        doReturn(List.of()).when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final Exception result  = assertThrows(CampaignKeywordNotFoundException.class,
-                ()-> keywordService.getKeywordsByCampaignId("2024-12-24","2024-12-24",1L) );
-        //then
-        assertThat(result.getMessage()).isEqualTo("해당 캠페인의 키워드가 없습니다.");
-    }
-    @Test
-    @DisplayName("getKeyWords(): Error 2. 조회 시작날과 끝의 순서가 이상할 때")
-    void test1_2(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2023-12-14";
-        //given
-        final Exception result  = assertThrows(InvalidDateFormatException.class,
-                ()-> keywordService.getKeywordsByCampaignId(start,end,1L) );
-        //then
-        assertThat(result.getMessage()).isEqualTo("날짜 형식이 이상합니다.");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"20-10-11","2024-1-1","2024-01-1","2024-01-10-17"})
-    @DisplayName("getKeyWords(): Error 3. LocalDate 형식 오류")
-    void test1_3(String wrongDataFormat){
-        //when
-        final String start = wrongDataFormat;
-        final String end = "2023-12-14";
-        //given
-        final Exception result  = assertThrows(InvalidDateFormatException.class,
-                ()-> keywordService.getKeywordsByCampaignId(start,end,1L) );
-        //then
-        assertThat(result.getMessage()).isEqualTo("날짜 형식이 이상합니다.");
-    }
-
-    @Test
     @DisplayName("getKeyWords(): Success")
-    void test1_4(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
-        doReturn(List.of(getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)
-                ,getKeyword("keyword2",0.0,0.0,0L,0L,0L,0.0)
-                ,getKeyword("keyword3",0.0,0.0,0L,0L,0L,0.0)))
-                .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
-        //then
-        assertThat(result.size()).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("getKeyWords(): Error 4. Roas, Cvr 계산 시 분모가 0 일 경우?")
-    void test1_5(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
-        doReturn(List.of(getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)
-                    ,getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)
-                    ,getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)))
-                .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
-        //then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).getKeyKeyword()).isEqualTo("keyword1");
-        assertThat(result.get(0).getKeyCvr()).isEqualTo(0.0);
-    }
-
-    @Test
-    @DisplayName("getKeyWords(): Success 2. keyClickRate Test")
-    void test1_6(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
-        doReturn(List.of(getKeyword("keyword1",660.0,0.0,10L,123L,0L,11000.0)
-                ,getKeyword("keyword1",0.0,0.0,10L,123L,0L,0.0)
-                ,getKeyword("keyword1",0.0,0.0,10L,123L,0L,0.0)))
-                .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
-        //then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).getKeyClicks()).isEqualTo(30);
-        assertThat(result.get(0).getKeyImpressions()).isEqualTo(369);
-        assertThat(result.get(0).getKeyClickRate()).isEqualTo(((Math.round(((double)30/(double) 369)*10000))/100.0));
-    }
-
-    @Test
-    @DisplayName("getKeyWords(): Success 3. cvr Test")
     void test1_7(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
-        doReturn(List.of(getKeyword("keyword1",660.0,0.0,10L,123L,2L,11000.0)
-                ,getKeyword("keyword1",0.0,0.0,10L,123L,4L,0.0)
-                ,getKeyword("keyword1",0.0,0.0,112L,123L,34L,0.0)))
-                .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
-        //then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).getKeyClicks()).isEqualTo(132);
-        assertThat(result.get(0).getKeyTotalSales()).isEqualTo(40);
-        assertThat(result.get(0).getKeyCvr()).isEqualTo(((Math.round(((double)40/(double) 132)*10000))/100.0));
-    }
-
-    @Test
-    @DisplayName("getKeyWords(): Success 4. cpc Test")
-    void test1_8(){
-        //when
-        final String start = "2024-12-14";
-        final String end = "2025-12-14";
-        doReturn(List.of(getKeyword("keyword1",660.0,0.0,10L,123L,2L,11000.0)
-                ,getKeyword("keyword1",660.0,0.0,10L,123L,4L,0.0)
-                ,getKeyword("keyword1",660.0,0.0,112L,123L,34L,0.0)))
-                .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
-        //given
-        final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
-        //then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).getKeyClicks()).isEqualTo(132);
-        assertThat(result.get(0).getKeyAdcost()).isEqualTo(1980);
-        assertThat(result.get(0).getKeyCpc()).isEqualTo(((Math.round(((double)1980/(double) 132)*100))/100.0));
-    }
-
-    @Test
-    @DisplayName("getKeyWords(): Success 5. 제외 키워드 처리")
-    void test1_9(){
         //when
         final String start = "2024-12-14";
         final String end = "2025-12-14";
@@ -189,9 +63,47 @@ public class KeywordServiceTest {
         assertThat(result.get(2).getKeyExcludeFlag()).isFalse();
     }
 
+    //기존 method 에서 분리
+    @Test
+    @DisplayName("checkDateFormat(): Error 1. 조회 시작날과 끝의 순서가 이상할 때")
+    void test2_1(){
+        //when
+        final String start = "2024-12-14";
+        final String end = "2023-12-14";
+        //given
+        final boolean result  = keywordService.checkDateFormat(start,end);
+        //then
+        assertThat(result).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"20-10-11","2024-1-1","2024-01-1","2024-01-10-17"})
+    @DisplayName("checkDateFormat(): Error 2. LocalDate 형식 오류")
+    void test2_2(String wrongDataFormat){
+        //when
+        final String start = wrongDataFormat;
+        final String end = "2023-12-14";
+        //given
+        final boolean result  = keywordService.checkDateFormat(start,end);
+        //then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("checkDateFormat(): Success")
+    void test2_3(){
+        //when
+        final String start = "2024-12-14";
+        final String end = "2025-12-14";
+        //given
+        final boolean result  = keywordService.checkDateFormat(start,end);
+        //then
+        assertThat(result).isTrue();
+    }
+
     @DisplayName("getExclusionKeywordsToSet(): Error1. 제외키워드가 없을 경우")
     @Test
-    void test2_1(){
+    void test3_1(){
         //when
         doThrow(IllegalArgumentException.class)
                 .when(exclusionKeywordService).getExclusionKeywords(1L);
@@ -203,7 +115,7 @@ public class KeywordServiceTest {
 
     @DisplayName("getExclusionKeywordsToSet(): Success")
     @Test
-    void test2_2(){
+    void test3_2(){
         //when
         doReturn(List.of(
                 getExclusionKeyword("exKey1",1L,LocalDate.now()),
@@ -216,6 +128,104 @@ public class KeywordServiceTest {
         assertThat(result).hasSize(3);
         assertThat(result.contains("exKey1")).isTrue();
         assertThat(result.contains("exKey4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("summeryKeywordData(): Error 1. 해당 데이터 없음")
+    void test4_1(){
+        //when
+        List<Keyword> data = List.of();
+        //given
+        final CampaignKeywordNotFoundException result  = assertThrows(CampaignKeywordNotFoundException.class,
+                ()-> keywordService.summeryKeywordData(data) );
+        //then
+        assertThat(result.getErrorCode().getMessage()).isEqualTo("해당 캠페인의 키워드가 없습니다.");
+    }
+
+    @Test
+    @DisplayName("summeryKeywordData(): Error 1. Roas, Cvr 계산 시 분모가 0 일 경우?")
+    void test4_2(){
+        //when
+        List<Keyword> data = List.of(getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)
+                ,getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0)
+                ,getKeyword("keyword1",0.0,0.0,0L,0L,0L,0.0));
+        //given
+        final HashMap<String,KeywordResponseDto> result  = keywordService.summeryKeywordData(data);
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("keyword1").getKeyKeyword()).isEqualTo("keyword1");
+        assertThat(result.get("keyword1").getKeyCvr()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("summeryKeywordData(): Success 1. keyClickRate Test")
+    void test4_3(){
+        //when
+        List<Keyword> data = List.of(getKeyword("keyword1",660.0,0.0,10L,123L,0L,11000.0)
+                ,getKeyword("keyword1",0.0,0.0,10L,123L,0L,0.0)
+                ,getKeyword("keyword1",0.0,0.0,10L,123L,0L,0.0));
+        //given
+        final HashMap<String,KeywordResponseDto> result  = keywordService.summeryKeywordData(data);
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("keyword1").getKeyClicks()).isEqualTo(30);
+        assertThat(result.get("keyword1").getKeyImpressions()).isEqualTo(369);
+        assertThat(result.get("keyword1").getKeyClickRate()).isEqualTo(((Math.round(((double)30/(double) 369)*10000))/100.0));
+    }
+
+    @Test
+    @DisplayName("summeryKeywordData(): Success 2. cvr Test")
+    void test4_4(){
+        //when
+        List<Keyword> data = List.of(getKeyword("keyword1",660.0,0.0,10L,123L,2L,11000.0)
+                ,getKeyword("keyword1",0.0,0.0,10L,123L,4L,0.0)
+                ,getKeyword("keyword1",0.0,0.0,112L,123L,34L,0.0));
+        //given
+        final HashMap<String,KeywordResponseDto> result  = keywordService.summeryKeywordData(data);
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("keyword1").getKeyClicks()).isEqualTo(132);
+        assertThat(result.get("keyword1").getKeyTotalSales()).isEqualTo(40);
+        assertThat(result.get("keyword1").getKeyCvr()).isEqualTo(((Math.round(((double)40/(double) 132)*10000))/100.0));
+    }
+
+    @Test
+    @DisplayName("summeryKeywordData(): Success 3. cpc Test")
+    void test4_5(){
+        //when
+        List<Keyword> data = List.of(getKeyword("keyword1",660.0,0.0,10L,123L,2L,11000.0)
+                ,getKeyword("keyword1",660.0,0.0,10L,123L,4L,0.0)
+                ,getKeyword("keyword1",660.0,0.0,112L,123L,34L,0.0));
+        //given
+        final HashMap<String,KeywordResponseDto> result  = keywordService.summeryKeywordData(data);
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get("keyword1").getKeyClicks()).isEqualTo(132);
+        assertThat(result.get("keyword1").getKeyAdcost()).isEqualTo(1980);
+        assertThat(result.get("keyword1").getKeyCpc()).isEqualTo(((Math.round(((double)1980/(double) 132)*100))/100.0));
+    }
+
+    @DisplayName("checkKeyType()")
+    @Test
+    void test5_1(){
+        //when
+        HashMap<String,KeywordResponseDto> map = new HashMap<>();
+        Set<String> exclusionKeys = new HashSet<>();
+        map.put("k1",KeywordResponseDto.builder().build());
+        map.put("k2",KeywordResponseDto.builder().build());
+        map.put("k3",KeywordResponseDto.builder().build());
+        map.put("k4",KeywordResponseDto.builder().build());
+        exclusionKeys.add("k2");
+        //given
+        final List<KeywordResponseDto> result = keywordService.checkKeyType(map,exclusionKeys);
+        //then
+        assertThat(result.get(1).getKeyExcludeFlag()).isEqualTo(true);
+    }
+
+    @DisplayName("findKeywordsByDateAndCampaignIdAndKeys() : ")
+    @Test
+    void test6_1(){
+
     }
 
     public ExclusionKeywordResponseDto getExclusionKeyword(String key,

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -2,6 +2,8 @@ package growup.spring.springserver.keyword.service;
 
 import growup.spring.springserver.exception.InvalidDateFormatException;
 import growup.spring.springserver.exception.keyword.CampaignKeywordNotFoundException;
+import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordResponseDto;
+import growup.spring.springserver.exclusionKeyword.service.ExclusionKeywordService;
 import growup.spring.springserver.keyword.domain.Keyword;
 import growup.spring.springserver.keyword.repository.KeywordRepository;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -7,6 +7,7 @@ import growup.spring.springserver.exclusionKeyword.service.ExclusionKeywordServi
 import growup.spring.springserver.keyword.domain.Keyword;
 import growup.spring.springserver.keyword.repository.KeywordRepository;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,10 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -205,7 +203,7 @@ public class KeywordServiceTest {
         assertThat(result.get("keyword1").getKeyCpc()).isEqualTo(((Math.round(((double)1980/(double) 132)*100))/100.0));
     }
 
-    @DisplayName("checkKeyType()")
+    @DisplayName("checkKeyType() : Success")
     @Test
     void test5_1(){
         //when
@@ -222,10 +220,48 @@ public class KeywordServiceTest {
         assertThat(result.get(1).getKeyExcludeFlag()).isEqualTo(true);
     }
 
-    @DisplayName("findKeywordsByDateAndCampaignIdAndKeys() : ")
+    @DisplayName("addBids() : Success")
     @Test
     void test6_1(){
+        //when
+        HashMap<String,KeywordResponseDto> map = new HashMap<>();
+        map.put("k1",KeywordResponseDto.builder().build());
+        map.put("k2",KeywordResponseDto.builder().build());
+        map.put("k3",KeywordResponseDto.builder().build());
+        map.put("k4",KeywordResponseDto.builder().build());
+        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidRequestDto("k1",1L),
+                getKeywordBidRequestDto("k2",2L),
+                getKeywordBidRequestDto("k3",3L),
+                getKeywordBidRequestDto("k4",4L));
+        //given
+        final List<KeywordResponseDto> result = keywordService.addBids(map,keywordBidDtos);
+        //then
+        assertThat(result.get(0).getBid()).isEqualTo(1L);
+        assertThat(result.get(1).getBid()).isEqualTo(2L);
+        assertThat(result.get(2).getBid()).isEqualTo(3L);
+        assertThat(result.get(3).getBid()).isEqualTo(4L);
+    }
 
+    @DisplayName("getKeywordsByDateAndCampaignIdAndKeys() : Success")
+    @Test
+    void test7_1(){
+        //when
+        doReturn(List.of(getKeyword("k1",0.0,0.0,0L,0L,0L,0.0)
+                        ,getKeyword("k2",0.0,0.0,0L,0L,0L,0.0)
+                        ,getKeyword("k3",0.0,0.0,0L,0L,0L,0.0)))
+                .when(keywordRepository).findKeywordsByDateAndCampaignIdAndKeys(any(LocalDate.class),any(LocalDate.class),any(Long.class),any(List.class));
+        final String start = "2024-12-14";
+        final String end = "2025-12-14";
+        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidRequestDto("k1",1L),
+                getKeywordBidRequestDto("k2",2L),
+                getKeywordBidRequestDto("k3",3L));
+        //given
+        List<KeywordResponseDto> result = keywordService.getKeywordsByDateAndCampaignIdAndKeys(start,end,1L,keywordBidDtos);
+        //then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getBid()).isEqualTo(1L);
+        assertThat(result.get(1).getBid()).isEqualTo(2L);
+        assertThat(result.get(2).getBid()).isEqualTo(3L);
     }
 
     public ExclusionKeywordResponseDto getExclusionKeyword(String key,
@@ -249,6 +285,7 @@ public class KeywordServiceTest {
                 .keyCvr(0.0)
                 .keyClickRate(0.0)
                 .keyRoas(0.0)
+                .keyDate(LocalDate.of(2024,11,1))
                 .keyKeyword(title)
                 .keyAdcost(adCost)
                 .keyCpc(cpc)
@@ -256,6 +293,12 @@ public class KeywordServiceTest {
                 .keyImpressions(impression)
                 .keyTotalSales(totalSale)
                 .keyAdsales(adSale)
+                .build();
+    }
+    public static KeywordBidDto getKeywordBidRequestDto(String keyword,Long bid){
+        return KeywordBidDto.builder()
+                .keyword(keyword)
+                .bid(bid)
                 .build();
     }
 

--- a/src/test/java/growup/spring/springserver/keywordBid/controller/KeywordBidControllerTest.java
+++ b/src/test/java/growup/spring/springserver/keywordBid/controller/KeywordBidControllerTest.java
@@ -1,0 +1,297 @@
+package growup.spring.springserver.keywordBid.controller;
+
+import com.nimbusds.jose.shaded.gson.Gson;
+import com.nimbusds.jose.shaded.gson.GsonBuilder;
+import growup.spring.springserver.annotation.WithAuthUser;
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.campaign.service.CampaignService;
+import growup.spring.springserver.exception.InvalidDateFormatException;
+import growup.spring.springserver.exception.campaign.CampaignNotFoundException;
+import growup.spring.springserver.global.config.JwtTokenProvider;
+import growup.spring.springserver.keyword.dto.KeywordResponseDto;
+import growup.spring.springserver.keyword.service.KeywordService;
+import growup.spring.springserver.keywordBid.KeywordBidController;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidRequestDtos;
+import growup.spring.springserver.keywordBid.dto.KeywordBidResponseDto;
+import growup.spring.springserver.keywordBid.service.KeywordBidService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static growup.spring.springserver.keywordBid.service.KeywordBidServiceTest.getCampaign;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(KeywordBidController.class)
+public class KeywordBidControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KeywordBidService keywordBidService;
+    @MockBean
+    private CampaignService campaignService;
+    @MockBean
+    private KeywordService keywordService;
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private Gson gson;
+
+    @BeforeEach
+    void set(){
+        gson = new Gson();
+    }
+
+    @WithAuthUser
+    @DisplayName("/adds: Error 1. body 누락")
+    @ParameterizedTest
+    @MethodSource("addsUrlIncorrectBodies")
+    void test1(KeywordBidRequestDtos body) throws Exception {
+        final String url = "/api/bid/adds";
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        resultActions.andExpectAll(
+                status().isBadRequest()
+        );
+    }
+    private static Stream<Arguments> addsUrlIncorrectBodies(){
+        return Stream.of(
+                Arguments.of(KeywordBidRequestDtos.builder()
+                        .campaignId(1L)
+                        .data(List.of())
+                        .build()
+                ),
+                Arguments.of(KeywordBidRequestDtos.builder()
+                        .campaignId(null)
+                        .data(List.of(KeywordBidDto.builder().build()))
+                        .build())
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/adds: Error 2. CampaignNotFound 예외 처리")
+    @Test
+    void test1_2() throws Exception {
+        doThrow(new CampaignNotFoundException()).when(campaignService).getMyCampaign(any(Long.class),any(String.class));
+        final String url = "/api/bid/adds";
+        final KeywordBidRequestDtos body = getRequest(1L,List.of(getKeywordBidDto(100L,"test")));
+        ResultActions result = mockMvc.perform(post(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("errorMessage").value("현재 등록된 캠페인이 없습니다.")
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/adds : Success")
+    @Test
+    void test1_3() throws Exception {
+        doReturn(getCampaign()).when(campaignService).getMyCampaign(any(Long.class),any(String.class));
+        doReturn(getKeywordBidResponseDto(3,2, List.of(getKeywordBidDto(1L,"k"),getKeywordBidDto(2L,"2k"))))
+                .when(keywordBidService)
+                .addKeywordBids(any(KeywordBidRequestDtos.class),any(Campaign.class));
+        final String url = "/api/bid/adds";
+        final KeywordBidRequestDtos body = getRequest(1L,List.of(getKeywordBidDto(1L,"k"),getKeywordBidDto(2L,"2k"),getKeywordBidDto(2L,null)));
+        ResultActions result = mockMvc.perform(post(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("data.requestNumber").value("3"),
+                jsonPath("data.responseNumber").value("2"),
+                jsonPath("data.response[0].keyword").value("k")
+        );
+    }
+
+    // 이 검증이 의미가 있을지 고민입니다.
+    @WithAuthUser
+    @DisplayName("/gets : Errors 1. 파라미터 날짜 관련 예외들")
+    @ParameterizedTest
+    @MethodSource("getsIncorrectParam")
+    void test2_1(String start, String end, String campaignId) throws Exception {
+        doReturn(getKeywordBidResponseDto(1,1,List.of())).when(keywordBidService).getKeywordBids(any());
+        doThrow(new InvalidDateFormatException()).when(keywordService).getKeywordsByDateAndCampaignIdAndKeys(any(),any(),any(),any());
+        final String url = "/api/bid/gets";
+        final ResultActions result = mockMvc.perform(get(url)
+                .param("start",start)
+                .param("end",end)
+                .param("campaignId",campaignId));
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("errorMessage").value("날짜 형식이 이상합니다.")
+        );
+    }
+    public static Stream<Arguments> getsIncorrectParam(){
+        return Stream.of(
+                //LocalDate 형식 오류
+                Arguments.of("2014-11","2015-11-01","1"),
+                // 시작 끝 관계 오류
+                Arguments.of("2024-11-01","2023-11-01","1")
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/gets: Success")
+    @Test
+    void test2_2() throws Exception {
+        doReturn(getKeywordBidResponseDto(1,1,List.of())).when(keywordBidService).getKeywordBids(any());
+        doReturn(List.of(getKeywordResDto())).when(keywordService).getKeywordsByDateAndCampaignIdAndKeys(any(),any(),any(),any());
+        final String url = "/api/bid/gets";
+        final ResultActions result = mockMvc.perform(get(url)
+                .param("start","2024-11-01")
+                .param("end","2024-12-01")
+                .param("campaignId","1"));
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("data[0].bid").value("100"),
+                jsonPath("data[0].keyKeyword").value("keyword")
+        ).andDo(print());
+    }
+
+
+    @WithAuthUser
+    @DisplayName("/update : Error 1. body 데이터 누락")
+    @ParameterizedTest
+    @MethodSource("addsUrlIncorrectBodies")
+    void test3_1(KeywordBidRequestDtos body) throws Exception {
+        final String url = "/api/bid/update";
+        final ResultActions result = mockMvc.perform(patch(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isBadRequest()
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/update : success")
+    @Test
+    void test3_2() throws Exception {
+        doReturn(
+                getKeywordBidResponseDto(2,1,List.of(getKeywordBidDto(200L,"k2")))
+        ).when(keywordBidService).updateKeywordBids(any(KeywordBidRequestDtos.class));
+        final String url = "/api/bid/update";
+        final KeywordBidRequestDtos body =
+                getRequest(1L, List.of(getKeywordBidDto(100L,"k1"),getKeywordBidDto(200L,"k2")));
+        final ResultActions result = mockMvc.perform(patch(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("data.requestNumber").value("2"),
+                jsonPath("data.responseNumber").value("1"),
+                jsonPath("data.response[0].keyword").value("k2")
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/delete : body 데이터 누락")
+    @ParameterizedTest
+    @MethodSource("addsUrlIncorrectBodies")
+    void test4_1(KeywordBidRequestDtos body) throws Exception {
+        final String url = "/api/bid/delete";
+        final ResultActions result = mockMvc.perform(delete(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isBadRequest()
+        );
+    }
+
+    @WithAuthUser
+    @DisplayName("/delete : success")
+    @Test
+    void test4_2() throws Exception {
+        doReturn(
+                getKeywordBidResponseDto(2,1,null)
+        ).when(keywordBidService).deleteByCampaignIdAndKeyword(any(KeywordBidRequestDtos.class));
+        final String url = "/api/bid/delete";
+        final KeywordBidRequestDtos body =
+                getRequest(1L, List.of(getKeywordBidDto(100L,"k1"),getKeywordBidDto(200L,"k2")));
+        final ResultActions result = mockMvc.perform(delete(url)
+                .content(gson.toJson(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()));
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("data.requestNumber").value("2"),
+                jsonPath("data.responseNumber").value("1")
+        ).andDo(print()); // 빈 값이 Json으로 변환되지 않는 것을 확인하기 위해 추가.
+    }
+
+    public KeywordBidResponseDto getKeywordBidResponseDto(int requestNum,
+                                                          int responseNum,
+                                                          List<KeywordBidDto> data){
+        return KeywordBidResponseDto.builder()
+                .requestNumber(requestNum)
+                .responseNumber(responseNum)
+                .response(data)
+                .build();
+    }
+    public KeywordBidRequestDtos getRequest(Long campaignId, List<KeywordBidDto> list){
+        return KeywordBidRequestDtos.builder()
+                .campaignId(campaignId)
+                .data(list)
+                .build();
+    }
+    public KeywordBidDto getKeywordBidDto(Long bid, String key){
+        return KeywordBidDto.builder()
+                .bid(bid)
+                .keyword(key)
+                .build();
+    }
+
+    public KeywordResponseDto getKeywordResDto(){
+        return KeywordResponseDto.builder()
+                .keyKeyword("keyword")
+                .keyAdcost(1.0)
+                .keyClickRate(0.8)
+                .keyClicks(10L)
+                .keyAdsales(1.0)
+                .keyCpc(1.0)
+                .keyCvr(1.0)
+                .keyImpressions(1L)
+                .keyRoas(1.0)
+                .keySearchType("test")
+                .keyTotalSales(1L)
+                .bid(100L)
+                .build();
+    }
+}

--- a/src/test/java/growup/spring/springserver/keywordBid/repository/KeywordBidRepositoryTest.java
+++ b/src/test/java/growup/spring/springserver/keywordBid/repository/KeywordBidRepositoryTest.java
@@ -1,0 +1,151 @@
+package growup.spring.springserver.keywordBid.repository;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.campaign.repository.CampaignRepository;
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class KeywordBidRepositoryTest {
+    @Autowired
+    private KeywordBidRepository keywordBidRepository;
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    private Campaign campaign;
+
+    @BeforeEach
+    void setUp(){
+        campaign = campaignRepository.save(Campaign.builder()
+                        .campaignId(1L)
+                        .camCampaignName("test")
+                        .build());
+    }
+
+    @DisplayName("save() : success ")
+    @Test
+    void test1_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L,"testKey");
+        //given
+        final KeywordBid result = keywordBidRepository.save(keywordBid);
+        //then
+        assertThat(result.getBid()).isEqualTo(1000L);
+        assertThat(result.getKeyword()).isEqualTo("testKey");
+        assertThat(result.getCampaign().getCampaignId()).isEqualTo(1L);
+    }
+
+    @DisplayName("savaALl() : success")
+    @Test
+    void test2_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey2");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,1000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,1000L, "testKey2");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,1000L, "testKey2");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        //given
+        keywordBidRepository.saveAll(keywordBids);
+        final List<KeywordBid> result = keywordBidRepository.findAll();
+        //then
+        assertThat(result).hasSize(4);
+        assertThat(result.get(0).getCampaign().getCampaignId()).isEqualTo(1L);
+    }
+
+    @DisplayName("findByCampaign_CampaignIdANDKeyword : success")
+    @Test
+    void test3_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,2000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,3000L, "testKey3");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,4000L, "testKey4");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        keywordBidRepository.saveAll(keywordBids);
+        //given
+        final KeywordBid result = keywordBidRepository.findByCampaign_CampaignIdANDKeyword(campaign.getCampaignId(),"testKey2").get();
+        //then
+        assertThat(result.getBid()).isEqualTo(2000L);
+    }
+
+    @DisplayName("existByCampaign_CampaignIdANDKeyword : success 1. 값이 존재")
+    @Test
+    void test4_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,2000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,3000L, "testKey3");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,4000L, "testKey4");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        keywordBidRepository.saveAll(keywordBids);
+        //given
+        final boolean result = keywordBidRepository.existsByCampaign_CampaignIdAndKeyword(campaign.getCampaignId(),"testKey2");
+        //then
+        assertThat(result).isEqualTo(true);
+    }
+
+    @DisplayName("existByCampaign_CampaignIdANDKeyword : success 2. 값이 미 존재")
+    @Test
+    void test4_2(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,2000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,3000L, "testKey3");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,4000L, "testKey4");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        keywordBidRepository.saveAll(keywordBids);
+        //given
+        final boolean result = keywordBidRepository.existsByCampaign_CampaignIdAndKeyword(campaign.getCampaignId(),"testKey5");
+        //then
+        assertThat(result).isEqualTo(false);
+    }
+
+    @DisplayName("findAllByCampaignId() : success")
+    @Test
+    void test5_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,2000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,3000L, "testKey3");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,4000L, "testKey4");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        keywordBidRepository.saveAll(keywordBids);
+        //given
+        final List<KeywordBid> results = keywordBidRepository.findAllByCampaign_CampaignId(1L);
+        //then
+        assertThat(results).hasSize(4);
+    }
+
+    @DisplayName("DeleteByCampaign_CampaignIDANDKeyword() : success")
+    @Test
+    void test6_1(){
+        //when
+        KeywordBid keywordBid = getKeywordBid(campaign,1000L, "testKey");
+        KeywordBid keywordBid2 = getKeywordBid(campaign,2000L, "testKey2");
+        KeywordBid keywordBid3 = getKeywordBid(campaign,3000L, "testKey3");
+        KeywordBid keywordBid4 = getKeywordBid(campaign,4000L, "testKey4");
+        List<KeywordBid> keywordBids = List.of(keywordBid,keywordBid2,keywordBid3,keywordBid4);
+        keywordBidRepository.saveAll(keywordBids);
+        //given
+        final int result = keywordBidRepository.deleteByCampaign_CampaignIdANDKeyword(campaign.getCampaignId(),"testKey");
+        //then
+        assertThat(result).isEqualTo(1);
+    }
+
+
+    public static KeywordBid getKeywordBid(Campaign campaign, Long bid, String keyword){
+        return KeywordBid.builder()
+                .campaign(campaign)
+                .bid(bid)
+                .keyword(keyword)
+                .build();
+    }
+}

--- a/src/test/java/growup/spring/springserver/keywordBid/service/KeywordBidServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keywordBid/service/KeywordBidServiceTest.java
@@ -1,0 +1,241 @@
+package growup.spring.springserver.keywordBid.service;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.campaign.service.CampaignService;
+import growup.spring.springserver.exception.keywordBid.KeywordBidNotFound;
+import growup.spring.springserver.global.exception.ErrorCode;
+import growup.spring.springserver.keywordBid.domain.KeywordBid;
+import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidRequestDtos;
+import growup.spring.springserver.keywordBid.dto.KeywordBidResponseDto;
+import growup.spring.springserver.keywordBid.repository.KeywordBidRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class KeywordBidServiceTest {
+    @InjectMocks
+    private KeywordBidService keywordBidService;
+
+    @Mock
+    private KeywordBidRepository keywordBidRepository;
+
+    @DisplayName("addKeywordBids():error 1. 빈 리스트를 저장할 떄")
+    @Test
+    void test1_1(){
+        //when
+        //Controller 단에서 CampaignService를 호출하기 떄문에 아래 코드는 의미가 없어진다.
+//        doReturn(getCampaign()).when(campaignService).getMyCampaign(1L,"test@test.com");
+        doReturn(true).when(keywordBidRepository).existsByCampaign_CampaignIdAndKeyword(1L,"passKey1");
+        final KeywordBidRequestDtos keywordBidRequestDtos = getKeywordBidRequestDtos(1L, List.of(getKeywordBidRequestDto("passKey1",1000L)));
+        //given
+        final KeywordBidResponseDto result = keywordBidService.addKeywordBids(keywordBidRequestDtos,getCampaign());
+        //then
+        assertThat(result.getRequestNumber()).isEqualTo(1);
+        assertThat(result.getResponseNumber()).isEqualTo(0);
+    }
+
+    @DisplayName("addKeywordBids(): Success")
+    @Test
+    void test1_2(){
+        //when
+//        doReturn(getCampaign()).when(campaignService).getMyCampaign(1L,"test@test.com");
+        doReturn(false).when(keywordBidRepository).existsByCampaign_CampaignIdAndKeyword(1L,"passKey1");
+        final KeywordBidRequestDtos keywordBidRequestDtos = getKeywordBidRequestDtos(1L, List.of(getKeywordBidRequestDto("passKey1",1000L)));
+        //given
+        final KeywordBidResponseDto result = keywordBidService.addKeywordBids(keywordBidRequestDtos,getCampaign());
+        //then
+        assertThat(result.getRequestNumber()).isEqualTo(1);
+        assertThat(result.getResponseNumber()).isEqualTo(1);
+    }
+
+    @DisplayName("checkOverlapKeywordBid(): Success. 이미 저장되있는 객체 구분")
+    @Test
+    void test2_1(){
+        //when
+        doReturn(false).when(keywordBidRepository).existsByCampaign_CampaignIdAndKeyword(1L,"passKey");
+        doReturn(false).when(keywordBidRepository).existsByCampaign_CampaignIdAndKeyword(1L,"passKey1");
+        doReturn(true).when(keywordBidRepository).existsByCampaign_CampaignIdAndKeyword(1L,"overlapKey");
+        List<KeywordBidDto> list = List.of(getKeywordBidRequestDto("passKey",100L),
+                        getKeywordBidRequestDto("passKey1",1000L),
+                        getKeywordBidRequestDto("overlapKey",1000L));
+        //given
+        final List<KeywordBid> result = keywordBidService.checkOverlapKeywordBid(list,getCampaign());
+        //then
+        assertThat(result).hasSize(2);
+    }
+
+    @DisplayName("getKeywordBids() : Success 1. 빈 리스트")
+    @Test
+    void test3_1(){
+        //when
+        doReturn(List.of()).when(keywordBidRepository).findAllByCampaign_CampaignId(1L);
+        //given
+        final KeywordBidResponseDto result = keywordBidService.getKeywordBids(1L);
+        //then
+        assertThat(result.getResponse()).hasSize(0);
+    }
+
+    @DisplayName("getKeywordBids() : Success 2.")
+    @Test
+    void test3_2(){
+        //when
+        doReturn(List.of(getKeywordBid("test1",1000L,getCampaign()),
+                        getKeywordBid("test1",1000L,getCampaign()),
+                        getKeywordBid("test1",1000L,getCampaign())))
+                .when(keywordBidRepository).findAllByCampaign_CampaignId(1L);
+        //given
+        final KeywordBidResponseDto result = keywordBidService.getKeywordBids(1L);
+        //then
+        assertThat(result.getResponse()).hasSize(3);
+    }
+
+    @DisplayName("updateKeywordBids():Success 1. 다중의 요청이 전부 성공")
+    @Test
+    void test4_1(){
+        //when
+        doReturn(Optional.of(getKeywordBid("passKey1",500L,getCampaign())))
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"passKey1");
+        doReturn(Optional.of(getKeywordBid("passKey2",500L,getCampaign())))
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"passKey2");
+        final KeywordBidRequestDtos keywordBidRequestDtos =
+                getKeywordBidRequestDtos(1L,
+                        List.of(getKeywordBidRequestDto("passKey1",1000L)
+                                , getKeywordBidRequestDto("passKey2",1500L)
+                        )
+                );
+        //given
+        final KeywordBidResponseDto result = keywordBidService.updateKeywordBids(keywordBidRequestDtos);
+        //then
+        assertThat(result.getResponse()).hasSize(2);
+        assertThat(result.getRequestNumber()).isEqualTo(2);
+        assertThat(result.getResponseNumber()).isEqualTo(2);
+        assertThat(result.getResponse().get(0).getBid()).isEqualTo(1000L);
+        assertThat(result.getResponse().get(1).getBid()).isEqualTo(1500L);
+    }
+
+    @DisplayName("updateKeywordBids():Success 2. 다중의 요청 중 일부 성공")
+    @Test
+    void test4_2(){
+        //when
+        doReturn(Optional.empty())
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"passKey1");
+        doReturn(Optional.of(getKeywordBid("passKey2",500L,getCampaign())))
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"passKey2");
+        final KeywordBidRequestDtos keywordBidRequestDtos =
+                getKeywordBidRequestDtos(1L,
+                        List.of(getKeywordBidRequestDto("passKey1",1000L)
+                                , getKeywordBidRequestDto("passKey2",1500L)
+                        )
+                );
+        //given
+        final KeywordBidResponseDto result = keywordBidService.updateKeywordBids(keywordBidRequestDtos);
+        //then
+        assertThat(result.getResponse()).hasSize(1);
+        assertThat(result.getRequestNumber()).isEqualTo(2);
+        assertThat(result.getResponseNumber()).isEqualTo(1);
+    }
+
+    @DisplayName("findKeywordBidByCampaignIDAndKey() : Error. 해당 입찰가 정보없음")
+    @Test
+    void test5_2(){
+        //when
+        doReturn(Optional.empty())
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"testKey1");
+        //given
+        final KeywordBidNotFound result = assertThrows(KeywordBidNotFound.class,
+                ()->keywordBidService.findKeywordBidByCampaignIDAndKey(1L,"testKey1"));
+        //then
+        assertThat(result.getErrorCode()).isEqualTo(ErrorCode.KEYWORDBID_NOT_FOUND);
+    }
+
+    @DisplayName("findKeywordBidByCampaignIDAndKey() : Success")
+    @Test
+    void test5_1(){
+        //when
+        doReturn(Optional.of(getKeywordBid("testKey1",1000L,getCampaign())))
+                .when(keywordBidRepository).findByCampaign_CampaignIdANDKeyword(1L,"testKey1");
+        //given
+        final KeywordBid result = keywordBidService.findKeywordBidByCampaignIDAndKey(1L,"testKey1");
+        //then
+        assertThat(result.getBid()).isEqualTo(1000L);
+        assertThat(result.getKeyword()).isEqualTo("testKey1");
+    }
+
+    @DisplayName("deleteKeywordBidByCampaignIdAndKey() : Success 1.다중 요청 시 일부 성공")
+    @Test
+    void test6_1(){
+        //when
+        doReturn(1)
+                .when(keywordBidRepository).deleteByCampaign_CampaignIdANDKeyword(1L,"key1");
+        doReturn(0)
+                .when(keywordBidRepository).deleteByCampaign_CampaignIdANDKeyword(1L,"key2");
+        final KeywordBidRequestDtos keywordBidRequestDtos =
+                getKeywordBidRequestDtos(1L,
+                        List.of(getKeywordBidRequestDto("key1",1000L)
+                                , getKeywordBidRequestDto("key2",1500L)
+                        )
+                );
+        //given
+        final KeywordBidResponseDto result = keywordBidService.deleteByCampaignIdAndKeyword(keywordBidRequestDtos);
+        //then
+        assertThat(result.getRequestNumber()).isEqualTo(2);
+        assertThat(result.getResponseNumber()).isEqualTo(1);
+    }
+
+    @DisplayName("deleteKeywordBidByCampaignIdAndKey() : Success 2.다중 요청 전부 성공")
+    @Test
+    void test6_2(){
+        //when
+        doReturn(1)
+                .when(keywordBidRepository).deleteByCampaign_CampaignIdANDKeyword(1L,"key1");
+        doReturn(1)
+                .when(keywordBidRepository).deleteByCampaign_CampaignIdANDKeyword(1L,"key2");
+        final KeywordBidRequestDtos keywordBidRequestDtos =
+                getKeywordBidRequestDtos(1L,
+                        List.of(getKeywordBidRequestDto("key1",1000L)
+                                , getKeywordBidRequestDto("key2",1500L)
+                        )
+                );
+        //given
+        final KeywordBidResponseDto result = keywordBidService.deleteByCampaignIdAndKeyword(keywordBidRequestDtos);
+        //then
+        assertThat(result.getRequestNumber()).isEqualTo(2);
+        assertThat(result.getResponseNumber()).isEqualTo(2);
+    }
+
+    public static Campaign getCampaign(){
+        return Campaign.builder().campaignId(1L).camCampaignName("testCamp").build();
+    }
+    public static KeywordBid getKeywordBid(String key,Long bid,Campaign campaign){
+        return KeywordBid.builder()
+                .bid(bid)
+                .keyword(key)
+                .campaign(campaign)
+                .build();
+    }
+    public static KeywordBidRequestDtos getKeywordBidRequestDtos(Long campaignId,List<KeywordBidDto> list){
+        return KeywordBidRequestDtos.builder()
+                .campaignId(campaignId)
+                .data(list)
+                .build();
+    }
+    public static KeywordBidDto getKeywordBidRequestDto(String keyword,Long bid){
+        return KeywordBidDto.builder()
+                .keyword(keyword)
+                .bid(bid)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 Description
<!-- PR에 대한 설명을 작성해주세요 -->
크게 2가지를 했습니다. 
1. 수동입찰가 (KeywordBId) 에 대한 CRUD
2. 기존 Keyword 도메인 Service 리팩토링

메서드에게 하나의 역할만 주려고 노력을 해봤습니다. 

## 📌 이 부분은 자세하게 봐주세요
- 수동입찰가 (KeywordBId) 에 대한 CRUD : KeywordBId 조회 (/gets) 관련하여 의견을 듣고 싶습니다. 
비효율적이라고 생각되는 부분이 있으면 알려주세요. 

- Keyword Service의 getKeywordsByCampaignId() 의 리팩토링에 대해 의견이 궁금합니다. 
더 쪼갤 수 있는 메서드 단위, 혹은 더 효과적인 테스트 코드가 고민입니다. 

## ✅ Check List
- [x] 테스트 코드가 있다면 추가했나요?
- [x] 새로운 의존성을 추가했다면 문서화했나요?
- [x] 변경사항에 대한 테스트를 진행했나요?
- [x] 코드 컨벤션을 지켰나요?

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/c75a8983-3ee1-4041-aaaf-3c963c990dd8)
벌써 100개가 넘는 단위 테스트가 작성했다니..
