### PR TITLE
입찰가 등록 및 캠패인 타입 분리 및 해당 키워드 판매 옵션 조회

### DIFF
--- a/src/main/java/growup/spring/springserver/campaign/TypeChangeCampaign.java
+++ b/src/main/java/growup/spring/springserver/campaign/TypeChangeCampaign.java
@@ -7,6 +7,7 @@ public class TypeChangeCampaign {
     public static CampaignResponseDto entityToResponseDto(Campaign c){
         return CampaignResponseDto.builder()
                 .campaignId(c.getCampaignId())
+                .camAdType(c.getCamAdType())
                 .title(c.getCamCampaignName())
                 .build();
     }

--- a/src/main/java/growup/spring/springserver/campaign/dto/CampaignResponseDto.java
+++ b/src/main/java/growup/spring/springserver/campaign/dto/CampaignResponseDto.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class CampaignResponseDto {
     String title;
     Long campaignId;
+    String camAdType;
 }

--- a/src/main/java/growup/spring/springserver/exception/RequestError.java
+++ b/src/main/java/growup/spring/springserver/exception/RequestError.java
@@ -1,0 +1,12 @@
+package growup.spring.springserver.exception;
+
+import growup.spring.springserver.global.exception.ErrorCode;
+import growup.spring.springserver.global.exception.GrouException;
+
+public class RequestError extends GrouException {
+  private static final ErrorCode errorCode = ErrorCode.EXECUTION_REQUEST_ERROR;
+
+  public RequestError(){
+    super(errorCode);
+  }
+}

--- a/src/main/java/growup/spring/springserver/execution/TypeChangeExecution.java
+++ b/src/main/java/growup/spring/springserver/execution/TypeChangeExecution.java
@@ -1,0 +1,13 @@
+package growup.spring.springserver.execution;
+
+import growup.spring.springserver.execution.domain.Execution;
+import growup.spring.springserver.execution.dto.ExecutionResponseDto;
+
+public class TypeChangeExecution {
+    public static ExecutionResponseDto entityToDto(Execution e){
+        return ExecutionResponseDto.builder()
+                .exeId(e.getExeId())
+                .exeProductName(e.getExeProductName())
+                .build();
+    }
+}

--- a/src/main/java/growup/spring/springserver/execution/controller/ExecutionController.java
+++ b/src/main/java/growup/spring/springserver/execution/controller/ExecutionController.java
@@ -1,0 +1,37 @@
+package growup.spring.springserver.execution.controller;
+
+import growup.spring.springserver.exception.RequestError;
+import growup.spring.springserver.execution.domain.Execution;
+import growup.spring.springserver.execution.dto.ExecutionResponseDto;
+import growup.spring.springserver.execution.service.ExecutionService;
+import growup.spring.springserver.global.common.CommonResponse;
+import growup.spring.springserver.execution.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/execution")
+@RestController
+public class ExecutionController {
+    @Autowired
+    private ExecutionService executionService;
+
+    @GetMapping("/getByCampaignIdAndExeIds")
+    public ResponseEntity<CommonResponse<?>> getByCampaignIdAndExeIds(
+            @RequestParam("campaignId") Long campaignId,
+            @RequestParam("exeIds") List<Long> exeIds) throws RequestError {
+
+        if (exeIds == null || exeIds.isEmpty() || campaignId == null) {
+            throw new RequestError();
+        }
+
+        List<Execution> result = executionService.getExecutionsByCampaignIdAndExeIds(campaignId, exeIds);
+        return new ResponseEntity<>(CommonResponse
+                .<List<ExecutionResponseDto>>builder("get Api success")
+                .data(result.stream().map(TypeChangeExecution::entityToDto).toList())
+                .build(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/growup/spring/springserver/execution/dto/ExecutionRequestDto.java
+++ b/src/main/java/growup/spring/springserver/execution/dto/ExecutionRequestDto.java
@@ -1,0 +1,22 @@
+package growup.spring.springserver.execution.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExecutionRequestDto {
+    @NotNull
+    Long campaignId;
+
+    @Size(min = 1)
+    List<Long> exeIds;
+}

--- a/src/main/java/growup/spring/springserver/execution/dto/ExecutionResponseDto.java
+++ b/src/main/java/growup/spring/springserver/execution/dto/ExecutionResponseDto.java
@@ -1,0 +1,15 @@
+package growup.spring.springserver.execution.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExecutionResponseDto {
+    private Long exeId;
+    private String exeProductName;
+}

--- a/src/main/java/growup/spring/springserver/execution/repository/ExecutionRepository.java
+++ b/src/main/java/growup/spring/springserver/execution/repository/ExecutionRepository.java
@@ -3,6 +3,7 @@ package growup.spring.springserver.execution.repository;
 import growup.spring.springserver.execution.domain.Execution;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +13,7 @@ public interface ExecutionRepository extends JpaRepository<Execution,Long> {
 
     @Query("SELECT e.id FROM Execution e WHERE e.campaign.campaignId = :campaignId")
     List<Long> findExecutionIdsByCampaignId(Long campaignId);
+
+    @Query("SELECT e FROM Execution e WHERE e.campaign.campaignId = :campaignId AND e.exeId IN :exeIds")
+    List<Execution> findByCampaignIdAndExeId(@Param("campaignId") Long campaignId, @Param("exeIds") List<Long> exeIds);
 }

--- a/src/main/java/growup/spring/springserver/execution/service/ExecutionService.java
+++ b/src/main/java/growup/spring/springserver/execution/service/ExecutionService.java
@@ -1,0 +1,19 @@
+package growup.spring.springserver.execution.service;
+
+import growup.spring.springserver.execution.domain.Execution;
+import growup.spring.springserver.execution.repository.ExecutionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ExecutionService {
+    @Autowired
+    private ExecutionRepository executionRepository;
+
+    public List<Execution> getExecutionsByCampaignIdAndExeIds(Long campaignId, List<Long> exeIds){
+        List<Execution> result = executionRepository.findByCampaignIdAndExeId(campaignId,exeIds);
+        return result;
+    }
+}

--- a/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
+++ b/src/main/java/growup/spring/springserver/global/error/ExceptionHandlerAdvice.java
@@ -2,17 +2,17 @@ package growup.spring.springserver.global.error;
 
 import growup.spring.springserver.exception.InvalidDateFormatException;
 import growup.spring.springserver.exception.campaign.CampaignNotFoundException;
+import growup.spring.springserver.exception.RequestError;
 import growup.spring.springserver.global.exception.GrouException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Map;
 
 
 @Slf4j
@@ -49,10 +49,23 @@ public class ExceptionHandlerAdvice {
         return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
     }
 
-    // controller 에서 LocalDate Parm 형식 오류 시 던지는 에러
+    @ExceptionHandler(RequestError.class)
+    public ResponseEntity<ErrorResponseDto> ExecutionRequestError(RequestError e) {
+        log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
+        return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
+    }
+
+    // controller 에서 LocalDate Param 형식 오류 시 던지는 에러
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponseDto> MethodArgumentTypeMismatchException() {
         InvalidDateFormatException e = new InvalidDateFormatException();
+        log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
+        return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
+    }
+    // controller 에서 Param 형식 오류 시 던지는 에러 (null)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponseDto> MissingServletRequestParameterException() {
+        RequestError e = new RequestError();
         log.error("Handler campaignNotFoundException message: {}", e.getErrorCode());
         return ErrorResponseDto.of(HttpStatus.BAD_REQUEST, e.getErrorCode().getMessage());
     }

--- a/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
+++ b/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
 
 
     //KeywordBid
-    KEYWORDBID_NOT_FOUND(HttpStatus.BAD_REQUEST,"입찰가 정보가 없습니다.")
+    KEYWORDBID_NOT_FOUND(HttpStatus.BAD_REQUEST,"입찰가 정보가 없습니다."),
+
+    //
+    EXECUTION_REQUEST_ERROR(HttpStatus.BAD_REQUEST,"잘못된 요청값 입니다.")
     ;
 
 

--- a/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
+++ b/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
@@ -3,6 +3,8 @@ package growup.spring.springserver.keyword;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;
 import growup.spring.springserver.keyword.domain.Keyword;
 
+import java.util.HashMap;
+
 public class TypeChangeKeyword {
     public static KeywordResponseDto entityToResponseDto(Keyword keyword){
         return KeywordResponseDto.builder()
@@ -18,6 +20,7 @@ public class TypeChangeKeyword {
                 .keyDate(keyword.getKeyDate().toString())
                 .keyExcludeFlag(false)
                 .keyBidFlag(false)
+                .keySalesOptions(keyword.getKeyProductSales())
                 .keySearchType(keyword.getKeySearchType())
                 .keyTotalSales(keyword.getKeyTotalSales())
                 .build();

--- a/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
+++ b/src/main/java/growup/spring/springserver/keyword/TypeChangeKeyword.java
@@ -17,6 +17,7 @@ public class TypeChangeKeyword {
                 .keyRoas((double) (Math.round(keyword.getKeyRoas()*100)/100))
                 .keyDate(keyword.getKeyDate().toString())
                 .keyExcludeFlag(false)
+                .keyBidFlag(false)
                 .keySearchType(keyword.getKeySearchType())
                 .keyTotalSales(keyword.getKeyTotalSales())
                 .build();

--- a/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
+++ b/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
@@ -34,7 +34,9 @@ public class KeywordResponseDto {
 
     private String keyDate;  // 날짜
 
-    private Boolean keyExcludeFlag = false;  // 제외여부
+    private Boolean keyExcludeFlag = false;// 제외여부
+
+    private Boolean keyBidFlag; // 수동입찰가 등록 여부
 
     private String keySearchType;// 검색 비검색
 

--- a/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
+++ b/src/main/java/growup/spring/springserver/keyword/dto/KeywordResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 @Data
 @Builder
@@ -41,6 +42,8 @@ public class KeywordResponseDto {
     private String keySearchType;// 검색 비검색
 
     private Long bid;
+
+    private Map<Long,Long> keySalesOptions;
 
     public void update(Keyword keyword){
         keyClicks += keyword.getKeyClicks();

--- a/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
+++ b/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
@@ -65,6 +65,8 @@ public class KeywordService {
                 continue;
             }
             if(map.containsKey(keyword.getKeyKeyword())){
+                KeywordResponseDto dto = map.get(keyword.getKeyKeyword());
+                summeryKeySalesOption(dto.getKeySalesOptions(),keyword.getKeyProductSales());
                 map.get(keyword.getKeyKeyword()).update(keyword);
                 continue;
             }
@@ -73,6 +75,12 @@ public class KeywordService {
         return map;
     }
 
+    public void summeryKeySalesOption(Map<Long,Long> originData, Map<Long,Long> inputData){
+        if(inputData == null) return;
+        for(Long inputKey : inputData.keySet()){
+            originData.put(inputKey,originData.getOrDefault(inputKey,0L)+inputData.get(inputKey));
+        }
+    }
     public List<KeywordResponseDto> checkKeyTypeExclusion(HashMap<String,KeywordResponseDto> map, Set<String> exclusions){
             List<KeywordResponseDto> keywordResponseDtos = new ArrayList<>();
             for(String key : map.keySet()){

--- a/src/test/java/growup/spring/springserver/execution/controller/ExecutionControllerTest.java
+++ b/src/test/java/growup/spring/springserver/execution/controller/ExecutionControllerTest.java
@@ -1,0 +1,120 @@
+package growup.spring.springserver.execution.controller;
+
+import com.nimbusds.jose.shaded.gson.Gson;
+import growup.spring.springserver.annotation.WithAuthUser;
+import growup.spring.springserver.execution.domain.Execution;
+import growup.spring.springserver.execution.dto.ExecutionRequestDto;
+import growup.spring.springserver.execution.dto.ExecutionResponseDto;
+import growup.spring.springserver.execution.service.ExecutionService;
+import growup.spring.springserver.global.config.JwtTokenProvider;
+import growup.spring.springserver.login.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ExecutionController.class)
+public class ExecutionControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    private Gson gson;
+
+    @MockBean
+    private ExecutionService executionService;
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @DisplayName("/api/execution/getByCampaignIdAndExeIds : Param 값 누락 시")
+    @ParameterizedTest
+    @MethodSource("nullBodies")
+    @WithAuthUser
+    void test1_1(Long campaignId, List<Long> lists) throws Exception {
+        gson = new Gson();
+        final String url = "/api/execution/getByCampaignIdAndExeIds";
+        final ExecutionRequestDto executionRequestDto = ExecutionRequestDto.builder()
+                .exeIds(lists)
+                .campaignId(campaignId)
+                .build();
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get(url)
+                .param("campaignId", String.valueOf(campaignId));
+
+        for (Long exeId : lists) {
+            requestBuilder.param("exeIds", String.valueOf(exeId));
+        }
+
+        final ResultActions resultActions = mockMvc.perform(requestBuilder);
+        resultActions.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("errorMessage").value("잘못된 요청값 입니다.")
+        ).andDo(print());
+    }
+
+    private static Stream<Arguments> nullBodies(){
+        return Stream.of(
+                Arguments.of(1L,List.of())
+        );
+    }
+
+    @DisplayName("/api/execution/getByCampaignIdAndExeIds : Success")
+    @Test
+    @WithAuthUser
+    void test1_2() throws Exception {
+        gson = new Gson();
+        final String url = "/api/execution/getByCampaignIdAndExeIds";
+        List<Long> lists = List.of(1L, 2L, 3L);
+        Long campaignId = 1L;
+
+        doReturn(List.of(getExecution(1L, "option1"),
+                getExecution(2L, "option2"),
+                getExecution(3L, "option3"))).when(executionService)
+                .getExecutionsByCampaignIdAndExeIds(any(Long.class), any(List.class));
+
+        // exeIds 파라미터를 여러 개로 전달
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get(url)
+                .param("campaignId", String.valueOf(campaignId));
+
+        for (Long exeId : lists) {
+            requestBuilder.param("exeIds", String.valueOf(exeId));
+        }
+
+        final ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("message").value("get Api success"),
+                jsonPath("data[0].exeId").value(1L),
+                jsonPath("data[0].exeProductName").value("option1")
+        ).andDo(print());
+    }
+
+    public Execution getExecution(Long exeId, String name){
+        return Execution.builder()
+                .exeId(exeId)
+                .exeProductName(name)
+                .build();
+    }
+}

--- a/src/test/java/growup/spring/springserver/execution/repository/ExecutionRepositoryTest.java
+++ b/src/test/java/growup/spring/springserver/execution/repository/ExecutionRepositoryTest.java
@@ -70,6 +70,32 @@ class ExecutionRepositoryTest {
         assertThat(result.isEmpty()); // 내부 리스트가 비어 있는지 확인
     }
 
+    @Test
+    @DisplayName("findByCampaignIdAndExeId() : Success 1. 조회한 값이 없을 떄")
+    void test3_1(){
+        // given
+        execution1 = executionRepository.save(newExecution(campaign, 91130550615L, "블랙", "안경 케이스 - 블랙"));
+        execution2 = executionRepository.save(newExecution(campaign, 91130550622L, "화이트", "안경 케이스 - 화이트"));
+        execution3 = executionRepository.save(newExecution(campaign2, 91130550623L, "블루", "안경 케이스 - 블루"));
+        // when
+        List<Execution> result = executionRepository.findByCampaignIdAndExeId(3L,List.of(91130550615L,91130550622L));
+        // then
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("findByCampaignIdAndExeId() : Success")
+    void test3_2(){
+        // given
+        execution1 = executionRepository.save(newExecution(campaign, 91130550615L, "블랙", "안경 케이스 - 블랙"));
+        execution2 = executionRepository.save(newExecution(campaign, 91130550622L, "화이트", "안경 케이스 - 화이트"));
+        execution3 = executionRepository.save(newExecution(campaign2, 91130550623L, "블루", "안경 케이스 - 블루"));
+        // when
+        List<Execution> result = executionRepository.findByCampaignIdAndExeId(1L,List.of(91130550615L,91130550622L));
+        // then
+        assertThat(result).hasSize(2);
+    }
+
 
     public Member newMember() {
         return Member.builder().email("test@test.com").build();

--- a/src/test/java/growup/spring/springserver/execution/service/ExecutionServiceTest.java
+++ b/src/test/java/growup/spring/springserver/execution/service/ExecutionServiceTest.java
@@ -1,0 +1,86 @@
+package growup.spring.springserver.execution.service;
+
+import growup.spring.springserver.campaign.domain.Campaign;
+import growup.spring.springserver.execution.domain.Execution;
+import growup.spring.springserver.execution.repository.ExecutionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionServiceTest {
+    @Mock
+    private ExecutionRepository executionRepository;
+    @InjectMocks
+    private ExecutionService executionService;
+
+    private Campaign campaign;
+
+    @BeforeEach
+    void setUp(){
+        campaign = Campaign.builder()
+                .camCampaignName("test")
+                .campaignId(1L)
+                .build();
+    }
+
+    @DisplayName("getExecutionsByCampaignIdAndExeIds() : 빈값이 조회 결과일 때")
+    @Test
+    void test1_1(){
+        //given
+        doReturn(List.of()).when(executionRepository).findByCampaignIdAndExeId(any(Long.class),any(List.class));
+        final List<Long> request = List.of(1L,2L,3L);
+        //when
+        final List<Execution> result = executionService.getExecutionsByCampaignIdAndExeIds(1L,request);
+        //then
+        assertThat(result).hasSize(0);
+    }
+
+    @DisplayName("getExecutionsByCampaignIdAndExeIds() : 빈값을 조회 시")
+    @Test
+    void test1_2(){
+        //given
+        doReturn(List.of()).when(executionRepository).findByCampaignIdAndExeId(any(Long.class),any(List.class));
+        final List<Long> request = List.of();
+        //when
+        final List<Execution> result = executionService.getExecutionsByCampaignIdAndExeIds(1L,request);
+        //then
+        assertThat(result).hasSize(0);
+    }
+
+    @DisplayName("getExecutionsByCampaignIdAndExeIds() : Success")
+    @Test
+    void test1_3(){
+        //given
+        doReturn(List.of(newExecution(campaign,1L,"details","name1"),
+                newExecution(campaign,2L,"details","name2"),
+                newExecution(campaign,3L,"details","name3"))).when(executionRepository).findByCampaignIdAndExeId(any(Long.class),any(List.class));
+        final List<Long> request = List.of(1L,2L,3L);
+        //when
+        final List<Execution> result = executionService.getExecutionsByCampaignIdAndExeIds(1L,request);
+        //then
+        assertThat(result).hasSize(3);
+    }
+
+    public Execution newExecution(Campaign campaign, long l, String detail, String name) {
+        return Execution.builder()
+                .exeId(l)
+                .exeDetailCategory(detail)
+                .exeProductName(name)
+                .campaign(campaign)
+                .build();
+    }
+
+
+
+}

--- a/src/test/java/growup/spring/springserver/keyword/repository/KeywordRepositoryTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/repository/KeywordRepositoryTest.java
@@ -86,6 +86,19 @@ public class KeywordRepositoryTest{
         assertThat(result).hasSize(3);
     }
 
+    @Test
+    @DisplayName("Keword의 salesOption이 null인 경우 JPA에서 빈 객체가 나올까? null 이 나올까?")
+    void test8(){
+        //when
+        LocalDate dataDate = LocalDate.parse("2024-12-25",DateTimeFormatter.ISO_DATE);
+        Keyword input = keywordRepository.save(getKeyword("title1",campaign,dataDate,false));
+        //given
+        final Keyword result = keywordRepository.findById(input.getId()).get();
+        //then
+        assertThat(result.getKeyKeyword()).isEqualTo("title1");
+        assertThat(result.getKeyProductSales()).isNull();
+    }
+
     public Keyword getKeyword(String title, Campaign campaign){
         return Keyword.builder()
                 .keyKeyword(title)

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -296,7 +296,7 @@ public class KeywordServiceTest {
     }
 
     @Test
-    @DisplayName("checkKeyTypeKeywordBid() : error 1.")
+    @DisplayName("checkKeyTypeKeywordBid() : Success")
     void test9_1(){
         //when
         List<KeywordResponseDto> list = List.of(KeywordResponseDto.builder().keyKeyword("k1").keyBidFlag(false).build(),
@@ -310,6 +310,41 @@ public class KeywordServiceTest {
         //then
         assertThat(list.get(1).getKeyBidFlag()).isEqualTo(true);
         assertThat(list.get(2).getKeyBidFlag()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("summeryKeySalesOption() : error 1. map Is Empty")
+    void test10_1(){
+        //when
+        Map<Long,Long> originData = new HashMap<>();
+        Map<Long,Long> inputData = new HashMap<>();
+        inputData.put(1L,3L);
+        inputData.put(5L,3L);
+        //given
+        keywordService.summeryKeySalesOption(originData,inputData);
+        //then
+        assertThat(originData).hasSize(2);
+        assertThat(originData.get(1L)).isEqualTo(3L);
+        assertThat(originData.get(5L)).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("summeryKeySalesOption() : Success")
+    void test10_2(){
+        //when
+        Map<Long,Long> originData = new HashMap<>();
+        originData.put(1L,1L);
+        originData.put(2L,1L);
+        originData.put(3L,1L);
+        Map<Long,Long> inputData = new HashMap<>();
+        inputData.put(1L,3L);
+        inputData.put(5L,3L);
+        //given
+        keywordService.summeryKeySalesOption(originData,inputData);
+        //then
+        assertThat(originData).hasSize(4);
+        assertThat(originData.get(1L)).isEqualTo(4L);
+        assertThat(originData.get(5L)).isEqualTo(3L);
     }
 
     public ExclusionKeywordResponseDto getExclusionKeyword(String key,

--- a/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/growup/spring/springserver/keyword/service/KeywordServiceTest.java
@@ -1,6 +1,5 @@
 package growup.spring.springserver.keyword.service;
 
-import growup.spring.springserver.exception.InvalidDateFormatException;
 import growup.spring.springserver.exception.keyword.CampaignKeywordNotFoundException;
 import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordResponseDto;
 import growup.spring.springserver.exclusionKeyword.service.ExclusionKeywordService;
@@ -8,11 +7,11 @@ import growup.spring.springserver.keyword.domain.Keyword;
 import growup.spring.springserver.keyword.repository.KeywordRepository;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;
 import growup.spring.springserver.keywordBid.dto.KeywordBidDto;
+import growup.spring.springserver.keywordBid.dto.KeywordBidResponseDto;
+import growup.spring.springserver.keywordBid.service.KeywordBidService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,7 +22,6 @@ import java.util.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
@@ -33,9 +31,12 @@ public class KeywordServiceTest {
     private KeywordRepository keywordRepository;
     @Mock
     private ExclusionKeywordService exclusionKeywordService;
+    @Mock
+    private KeywordBidService keywordBidService;
 
     @InjectMocks
     private KeywordService keywordService;
+
 
     @Test
     @DisplayName("getKeyWords(): Success")
@@ -43,22 +44,36 @@ public class KeywordServiceTest {
         //when
         final LocalDate start = LocalDate.of(2024,12,14);
         final LocalDate end = LocalDate.of(2025,1,14);
-        doReturn(List.of(getKeyword("exKey1",660.0,0.0,10L,123L,2L,11000.0)
-                ,getKeyword("exKey2",660.0,0.0,10L,123L,4L,0.0)
-                ,getKeyword("exKey3",660.0,0.0,112L,123L,34L,0.0)))
+        doReturn(List.of(getKeyword("exKeyAndBid",660.0,0.0,10L,123L,2L,11000.0)
+                ,getKeyword("exKey",660.0,0.0,10L,123L,4L,0.0)
+                ,getKeyword("bidKey",660.0,0.0,112L,123L,34L,0.0)
+                ,getKeyword("nonKey",660.0,0.0,112L,123L,34L,0.0)))
                 .when(keywordRepository).findAllByDateANDCampaign(any(LocalDate.class),any(LocalDate.class),any(Long.class));
         doReturn(List.of(
-                getExclusionKeyword("exKey1",1L,LocalDate.now()),
-                getExclusionKeyword("exKey10",1L,LocalDate.now()),
-                getExclusionKeyword("exKey100",1L,LocalDate.now()))
-        ).when(exclusionKeywordService).getExclusionKeywords(1L);
+                getExclusionKeyword("exKeyAndBid",1L,LocalDate.now()),
+                getExclusionKeyword("exKey",1L,LocalDate.now()))
+        ).when(exclusionKeywordService).getExclusionKeywords(any(Long.class));
+        doReturn(getKeywordBidResponseDto(2,2,
+                List.of(getKeywordBidDto("exKeyAndBid",10L),
+                        getKeywordBidDto("bidKey",10L)))
+        ).when(keywordBidService).getKeywordBids(any(Long.class));
         //given
         final List<KeywordResponseDto> result  = keywordService.getKeywordsByCampaignId(start,end,1L);
         //then
-        assertThat(result.size()).isEqualTo(3);
-        assertThat(result.get(0).getKeyExcludeFlag()).isTrue();
-        assertThat(result.get(1).getKeyExcludeFlag()).isFalse();
-        assertThat(result.get(2).getKeyExcludeFlag()).isFalse();
+        for(KeywordResponseDto dto : result){
+            if(dto.getKeyKeyword().equals("exKeyAndBid")){
+                assertThat(dto.getKeyBidFlag()).isTrue();
+                assertThat(dto.getKeyExcludeFlag()).isTrue();
+            }
+            if(dto.getKeyKeyword().equals("bidKey")){
+                assertThat(dto.getKeyBidFlag()).isTrue();
+                assertThat(dto.getKeyExcludeFlag()).isFalse();
+            }
+            if(dto.getKeyKeyword().equals("exKey")){
+                assertThat(dto.getKeyBidFlag()).isFalse();
+                assertThat(dto.getKeyExcludeFlag()).isTrue();
+            }
+        }
     }
 
     //기존 method 에서 분리
@@ -190,7 +205,7 @@ public class KeywordServiceTest {
         assertThat(result.get("keyword1").getKeyCpc()).isEqualTo(((Math.round(((double)1980/(double) 132)*100))/100.0));
     }
 
-    @DisplayName("checkKeyType() : Success")
+    @DisplayName("checkKeyTypeExclusion() : Success")
     @Test
     void test5_1(){
         //when
@@ -202,7 +217,7 @@ public class KeywordServiceTest {
         map.put("k4",KeywordResponseDto.builder().build());
         exclusionKeys.add("k2");
         //given
-        final List<KeywordResponseDto> result = keywordService.checkKeyType(map,exclusionKeys);
+        final List<KeywordResponseDto> result = keywordService.checkKeyTypeExclusion(map,exclusionKeys);
         //then
         assertThat(result.get(1).getKeyExcludeFlag()).isEqualTo(true);
     }
@@ -216,10 +231,10 @@ public class KeywordServiceTest {
         map.put("k2",KeywordResponseDto.builder().build());
         map.put("k3",KeywordResponseDto.builder().build());
         map.put("k4",KeywordResponseDto.builder().build());
-        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidRequestDto("k1",1L),
-                getKeywordBidRequestDto("k2",2L),
-                getKeywordBidRequestDto("k3",3L),
-                getKeywordBidRequestDto("k4",4L));
+        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidDto("k1",1L),
+                getKeywordBidDto("k2",2L),
+                getKeywordBidDto("k3",3L),
+                getKeywordBidDto("k4",4L));
         //given
         final List<KeywordResponseDto> result = keywordService.addBids(map,keywordBidDtos);
         //then
@@ -239,9 +254,9 @@ public class KeywordServiceTest {
                 .when(keywordRepository).findKeywordsByDateAndCampaignIdAndKeys(any(LocalDate.class),any(LocalDate.class),any(Long.class),any(List.class));
         final LocalDate start = LocalDate.of(2024,12,14);
         final LocalDate end = LocalDate.of(2025,1,14);
-        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidRequestDto("k1",1L),
-                getKeywordBidRequestDto("k2",2L),
-                getKeywordBidRequestDto("k3",3L));
+        List<KeywordBidDto> keywordBidDtos = List.of(getKeywordBidDto("k1",1L),
+                getKeywordBidDto("k2",2L),
+                getKeywordBidDto("k3",3L));
         //given
         List<KeywordResponseDto> result = keywordService.getKeywordsByDateAndCampaignIdAndKeys(start,end,1L,keywordBidDtos);
         //then
@@ -249,6 +264,52 @@ public class KeywordServiceTest {
         assertThat(result.get(0).getBid()).isEqualTo(1L);
         assertThat(result.get(1).getBid()).isEqualTo(2L);
         assertThat(result.get(2).getBid()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("getBidKeywordToSet() : Error 1. 빈 리스트를 받아 올 떄")
+    void test8_1(){
+        //when
+        doReturn(getKeywordBidResponseDto(0,0,List.of())).when(keywordBidService).getKeywordBids(any(Long.class));
+        //given
+        final Set<String> results = keywordService.getBidKeywrodToSet(1L);
+        //then
+        assertThat(results).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("getBidKeywordToSet() : Success")
+    void test8_2(){
+        //when
+        doReturn(getKeywordBidResponseDto(4,4,
+                List.of(getKeywordBidDto("overlapKey",10L),
+                        getKeywordBidDto("overlapKey",10L),
+                        getKeywordBidDto("test1",10L),
+                        getKeywordBidDto("test2",10L))
+                )).when(keywordBidService).getKeywordBids(any(Long.class));
+        //given
+        final Set<String> results = keywordService.getBidKeywrodToSet(1L);
+        //then
+        assertThat(results).hasSize(3);
+        assertThat(results.contains("test1")).isTrue();
+        assertThat(results.contains("test3")).isFalse();
+    }
+
+    @Test
+    @DisplayName("checkKeyTypeKeywordBid() : error 1.")
+    void test9_1(){
+        //when
+        List<KeywordResponseDto> list = List.of(KeywordResponseDto.builder().keyKeyword("k1").keyBidFlag(false).build(),
+                                                KeywordResponseDto.builder().keyKeyword("k2").keyBidFlag(false).build(),
+                                                KeywordResponseDto.builder().keyKeyword("k3").keyBidFlag(false).build(),
+                                                KeywordResponseDto.builder().keyKeyword("k4").keyBidFlag(false).build());
+        Set<String> bidKey = new HashSet<>();
+        bidKey.add("k2");
+        //given
+        keywordService.checkKeyTypeKeywordBid(list,bidKey);
+        //then
+        assertThat(list.get(1).getKeyBidFlag()).isEqualTo(true);
+        assertThat(list.get(2).getKeyBidFlag()).isEqualTo(false);
     }
 
     public ExclusionKeywordResponseDto getExclusionKeyword(String key,
@@ -282,10 +343,20 @@ public class KeywordServiceTest {
                 .keyAdsales(adSale)
                 .build();
     }
-    public static KeywordBidDto getKeywordBidRequestDto(String keyword,Long bid){
+    public static KeywordBidDto getKeywordBidDto(String keyword, Long bid){
         return KeywordBidDto.builder()
                 .keyword(keyword)
                 .bid(bid)
+                .build();
+    }
+
+    public static KeywordBidResponseDto getKeywordBidResponseDto(int request,
+                                                                 int response,
+                                                                 List<KeywordBidDto> data){
+        return KeywordBidResponseDto.builder()
+                .responseNumber(response)
+                .requestNumber(request)
+                .response(data)
                 .build();
     }
 


### PR DESCRIPTION
## 📝 Description

- 서비스 요청에 따른 Dto의 자잘한 타입을 추가했습니다. 
   캠패인 광고 타입 분리, keywordDto 에 SalesOptions 추가...
- KeySaleOption의 Json에 이제 String 이 들어가니 아마 살짝 코드가 수정될 것 같습니다.
- Keyword 조회 시 map형태로 SaleOption에 대한 데이터를 넣어서 보내줍니다.

## ✅ Check List
- [x] 테스트 코드가 있다면 추가했나요?
- [] 새로운 의존성을 추가했다면 문서화했나요?
- [x] 변경사항에 대한 테스트를 진행했나요?
- [x] 코드 컨벤션을 지켰나요?
