### PR TITLE
Refactor/keywords 키워드 리팩토링

### DIFF
--- a/src/main/java/growup/spring/springserver/exception/exclusionKeyword/ExclusionKeyNotFound.java
+++ b/src/main/java/growup/spring/springserver/exception/exclusionKeyword/ExclusionKeyNotFound.java
@@ -1,0 +1,13 @@
+package growup.spring.springserver.exception.exclusionKeyword;
+
+import growup.spring.springserver.global.exception.ErrorCode;
+import growup.spring.springserver.global.exception.GrouException;
+
+public class ExclusionKeyNotFound extends GrouException {
+
+    private static final ErrorCode errorCode = ErrorCode.EXCLUSIONKEY_NOT_FOUND;
+
+    public ExclusionKeyNotFound(){
+        super(errorCode);
+    }
+}

--- a/src/main/java/growup/spring/springserver/exception/exclusionKeyword/ExistExclusionKeyword.java
+++ b/src/main/java/growup/spring/springserver/exception/exclusionKeyword/ExistExclusionKeyword.java
@@ -1,0 +1,13 @@
+package growup.spring.springserver.exception.exclusionKeyword;
+
+import growup.spring.springserver.global.exception.ErrorCode;
+import growup.spring.springserver.global.exception.GrouException;
+
+public class ExistExclusionKeyword extends GrouException {
+
+    private static final ErrorCode errorCode = ErrorCode.ALREADY_EXIST_KEYWORD;
+
+    public ExistExclusionKeyword(){
+        super(errorCode);
+    }
+}

--- a/src/main/java/growup/spring/springserver/exclusionKeyword/controller/ExclusionKeywordController.java
+++ b/src/main/java/growup/spring/springserver/exclusionKeyword/controller/ExclusionKeywordController.java
@@ -1,5 +1,6 @@
 package growup.spring.springserver.exclusionKeyword.controller;
 
+import growup.spring.springserver.exception.exclusionKeyword.ExclusionKeyNotFound;
 import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordRequestDto;
 import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordResponseDto;
 import growup.spring.springserver.exclusionKeyword.service.ExclusionKeywordService;
@@ -10,10 +11,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RequestMapping("/api/exclusionKeyword")
@@ -24,29 +28,32 @@ public class ExclusionKeywordController {
     private ExclusionKeywordService exclusionKeywordService;
 
     @PostMapping("/addExclusionKeyword")
-    public ResponseEntity<CommonResponse<?>> addExclusionKeyword(@Valid @RequestBody ExclusionKeywordRequestDto exclusionKeywordRequestDto, BindingResult bindingResult) throws BindException {
+    public ResponseEntity<CommonResponse<?>> addExclusionKeyword(@Valid @RequestBody ExclusionKeywordRequestDto exclusionKeywordRequestDto,
+                                                                 BindingResult bindingResult,
+                                                                 @AuthenticationPrincipal UserDetails userDetails) throws BindException {
         log.info("start addExclusionKeyword");
         if (bindingResult.hasErrors()) {
             log.info("bindExceptions is throw");
             throw new BindException(bindingResult);
         }
-        final List<ExclusionKeywordResponseDto> result = exclusionKeywordService.addExclusionKeyword(exclusionKeywordRequestDto);
+        final ExclusionKeywordResponseDto result = exclusionKeywordService.addExclusionKeyword(exclusionKeywordRequestDto,userDetails.getUsername());
         log.info("end addExclusionKeyword");
         return new ResponseEntity<>(CommonResponse
-                .<List<ExclusionKeywordResponseDto>>builder("success : add exclusionKeyword")
+                .<ExclusionKeywordResponseDto>builder("success : add exclusionKeyword")
                 .data(result)
                 .build(), HttpStatus.OK);
     }
 
     @DeleteMapping("/remove")
     public ResponseEntity<CommonResponse<?>> removeExclusionKeyword(@Valid @RequestBody ExclusionKeywordRequestDto exclusionKeywordRequestDto,
-                                                                    BindingResult bindingResult) throws BindException {
+                                                                    BindingResult bindingResult,
+                                                                    @AuthenticationPrincipal UserDetails userDetails) throws BindException {
         log.info("start removeExclusionKeyword");
         if (bindingResult.hasErrors()) {
             log.info("bindExceptions is throw");
             throw new BindException(bindingResult);
         }
-        final boolean result = exclusionKeywordService.deleteExclusionKeyword(exclusionKeywordRequestDto);
+        final boolean result = exclusionKeywordService.deleteExclusionKeyword(exclusionKeywordRequestDto,userDetails.getUsername());
         return new ResponseEntity<>(CommonResponse
                 .<Boolean>builder("success : remove")
                 .data(result)
@@ -55,12 +62,16 @@ public class ExclusionKeywordController {
 
     @GetMapping("/getExclusionKeywords")
     public ResponseEntity<CommonResponse<?>> getExclusionKeywords(@RequestParam(value = "campaignId") Long campaignId){
-        List<ExclusionKeywordResponseDto> result = exclusionKeywordService.getExclusionKeywords(campaignId);
+        List<ExclusionKeywordResponseDto> result;
+        try {
+            result = exclusionKeywordService.getExclusionKeywords(campaignId);
+
+        }catch (ExclusionKeyNotFound e){
+            result = new ArrayList<>();
+        }
         return new ResponseEntity<>(CommonResponse
                 .<List<ExclusionKeywordResponseDto>>builder("success : getExclusionKeywords")
                 .data(result)
                 .build(), HttpStatus.OK);
     }
-
-
 }

--- a/src/main/java/growup/spring/springserver/exclusionKeyword/dto/ExclusionKeywordResponseDto.java
+++ b/src/main/java/growup/spring/springserver/exclusionKeyword/dto/ExclusionKeywordResponseDto.java
@@ -1,5 +1,6 @@
 package growup.spring.springserver.exclusionKeyword.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,8 +8,11 @@ import java.time.LocalDate;
 
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExclusionKeywordResponseDto {
     String exclusionKeyword;
     Long campaignId;
     LocalDate addTime;
+    int requestData;
+    int responseData;
 }

--- a/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
+++ b/src/main/java/growup/spring/springserver/global/exception/ErrorCode.java
@@ -26,9 +26,12 @@ public enum ErrorCode {
     //Global
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 이상합니다."),
 
-
     //KeywordBid
     KEYWORDBID_NOT_FOUND(HttpStatus.BAD_REQUEST,"입찰가 정보가 없습니다."),
+
+    //ExclusionKeyword
+    ALREADY_EXIST_KEYWORD(HttpStatus.BAD_REQUEST,"이미 제외 키워드가 존재합니다"),
+    EXCLUSIONKEY_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 제외키워드가 없습니다"),
 
     // Execution
     EXECUTION_REQUEST_ERROR(HttpStatus.BAD_REQUEST,"잘못된 요청값 입니다."),

--- a/src/main/java/growup/spring/springserver/keyword/controller/KeywordController.java
+++ b/src/main/java/growup/spring/springserver/keyword/controller/KeywordController.java
@@ -1,5 +1,6 @@
 package growup.spring.springserver.keyword.controller;
 
+import growup.spring.springserver.exception.keyword.CampaignKeywordNotFoundException;
 import growup.spring.springserver.global.common.CommonResponse;
 import growup.spring.springserver.keyword.dto.KeywordResponseDto;
 import growup.spring.springserver.keyword.dto.KeywordTotalDataResDto;
@@ -13,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequestMapping("/api/keyword")
@@ -27,9 +29,14 @@ public class KeywordController {
                                                                      @RequestParam("end") LocalDate end,
                                                                      @RequestParam("campaignId") Long campaignId,
                                                                      @AuthenticationPrincipal UserDetails userDetails){
-        log.info("start getKeywordAboutCampaign target "+ userDetails.getUsername());
-        List<KeywordResponseDto> result = keywordService.getKeywordsByCampaignId(start,end,campaignId);
-        log.info("end getKeywordAboutCampaign target "+ userDetails.getUsername());
+//        log.info("start getKeywordAboutCampaign target "+ userDetails.getUsername());
+        List<KeywordResponseDto> result;
+        try {
+            result = keywordService.getKeywordsByCampaignId(start,end,campaignId);
+        }catch (CampaignKeywordNotFoundException e){
+            result = new ArrayList<>();
+        }
+//        log.info("end getKeywordAboutCampaign target "+ userDetails.getUsername());
         return new ResponseEntity<>(CommonResponse
                 .<List<KeywordResponseDto>>builder("success : get keywords")
                 .data(result)

--- a/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
+++ b/src/main/java/growup/spring/springserver/keyword/service/KeywordService.java
@@ -1,6 +1,7 @@
 package growup.spring.springserver.keyword.service;
 
 import growup.spring.springserver.exception.InvalidDateFormatException;
+import growup.spring.springserver.exception.exclusionKeyword.ExclusionKeyNotFound;
 import growup.spring.springserver.exception.keyword.CampaignKeywordNotFoundException;
 import growup.spring.springserver.exclusionKeyword.dto.ExclusionKeywordResponseDto;
 import growup.spring.springserver.exclusionKeyword.service.ExclusionKeywordService;
@@ -42,7 +43,7 @@ public class KeywordService {
         List<ExclusionKeywordResponseDto> exclusionKeywordResponseDtos;
         try {
             exclusionKeywordResponseDtos = exclusionKeywordService.getExclusionKeywords(campaignId);
-        }catch (IllegalArgumentException e){
+        }catch (ExclusionKeyNotFound e){
             exclusionKeywordResponseDtos = List.of();
         }
         return exclusionKeywordResponseDtos.stream()

--- a/src/test/java/growup/spring/springserver/exclusionKeyword/controller/ExclusionKeywordControllerTest.java
+++ b/src/test/java/growup/spring/springserver/exclusionKeyword/controller/ExclusionKeywordControllerTest.java
@@ -106,14 +106,10 @@ public class ExclusionKeywordControllerTest {
                 .campaignId(1L)
                 .build();
         //given
-        doReturn(List.of(ExclusionKeywordResponseDto.builder()
-                        .exclusionKeyword("key")
-                        .campaignId(1L)
-                        .build(),
-                ExclusionKeywordResponseDto.builder()
-                        .exclusionKeyword("key2")
-                        .campaignId(1L)
-                        .build())).when(exclusionKeywordService).addExclusionKeyword(any(ExclusionKeywordRequestDto.class));
+        doReturn(ExclusionKeywordResponseDto.builder()
+                .requestData(5)
+                .responseData(4)
+                .build()).when(exclusionKeywordService).addExclusionKeyword(any(ExclusionKeywordRequestDto.class),any(String.class));
         ResultActions resultActions = mockMvc.perform(post(url)
                 .content(gson.toJson(body))
                 .contentType(MediaType.APPLICATION_JSON)
@@ -122,9 +118,8 @@ public class ExclusionKeywordControllerTest {
         resultActions.andExpectAll(
                 status().isOk(),
                 jsonPath("message").value("success : add exclusionKeyword"),
-                jsonPath("data[0].exclusionKeyword").value("key"),
-                jsonPath("data[1].exclusionKeyword").value("key2"),
-                jsonPath("data[0].campaignId").value(1L)
+                jsonPath("data.requestData").value(5),
+                jsonPath("data.responseData").value(4)
         ).andDo(print());
     }
 
@@ -184,7 +179,7 @@ public class ExclusionKeywordControllerTest {
                 .exclusionKeyword(List.of("key1","key2"))
                 .campaignId(1L)
                 .build();
-        doReturn(true).when(exclusionKeywordService).deleteExclusionKeyword(any(ExclusionKeywordRequestDto.class));
+        doReturn(true).when(exclusionKeywordService).deleteExclusionKeyword(any(ExclusionKeywordRequestDto.class),any(String.class));
         //then
         ResultActions resultActions = mockMvc.perform(delete(url).content(gson.toJson(body))
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 📝 Description
- 제외 키워드 다중 등록이 가능하도록 코드를 수정.
  에러가 발생 시 이를 잡아서, 실패한 키워드의 숫자를 카운트하여 성공 횟수 전달
- Campaign을 찾는 메서드 CampaignService Layer에서 불러서 사용하여, 코드 중복 제거
- addExclusinKeyword 메서드 리팩토링
- 리턴해주는 데이터를 변경
- 제외 키워드 및 키워드 조회하지 못할때, 발생 한 예외를 controller 에서 잡아서 빈 리스트를 전달.
- 각 기능 변화에 따른 테스트 코드 수정.
## ✅ Check List
- [x ] 테스트 코드가 있다면 추가했나요?
- [ ] 새로운 의존성을 추가했다면 문서화했나요?
- [x] 변경사항에 대한 테스트를 진행했나요?
- [x] 코드 컨벤션을 지켰나요?

## 📸 Screenshots
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
