### PR TITLE
[feat] 구글 로그인 구현 

### DIFF
--- a/src/main/java/growup/spring/springserver/global/common/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/growup/spring/springserver/global/common/OAuth2AuthenticationSuccessHandler.java
@@ -1,21 +1,20 @@
 package growup.spring.springserver.global.common;
 
+import growup.spring.springserver.global.oauth.OAuth2RedirectUrlProvider;
+import growup.spring.springserver.global.oauth.OAuth2UserInfo;
+import growup.spring.springserver.global.oauth.OAuth2UserInfoFactory;
 import growup.spring.springserver.global.config.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.annotations.Comment;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 @Component
@@ -26,42 +25,40 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        // OAuth2User 정보 가져오기
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        log.info("onAuthenticationSuccess : 시작");
+        // OAuth2AuthenticationToken에서 registrationId 가져오기
+        if (!(authentication instanceof OAuth2AuthenticationToken oauthToken)) {
+            throw new IllegalArgumentException("Authentication is not an instance of OAuth2AuthenticationToken");
+        }
+        String registrationId = oauthToken.getAuthorizedClientRegistrationId();
 
-        // 사용자 정보 추출 (카카오 사용자 정보)
-        Optional<Map<String, Object>> kakaoAccountOpt = safeCastToMap(oAuth2User.getAttributes().get("kakao_account"));
+        log.info("registrationId: {}", registrationId);
 
-        String email = kakaoAccountOpt
-                .map(kakaoAccount -> (String) kakaoAccount.get("email"))
-                .orElseThrow(() -> new IllegalArgumentException("Kakao account data is missing"));
+        if (registrationId == null) {
+            throw new IllegalArgumentException("OAuth provider not found");
+        }
 
-        Optional<Map<String, Object>> propertiesOpt = safeCastToMap(oAuth2User.getAttributes().get("properties"));
+        OAuth2User oAuth2User = oauthToken.getPrincipal();
+        log.info("oAuth2User :{}", oAuth2User);
 
-        String nickname = propertiesOpt
-                .map(properties -> (String) properties.get("nickname"))
-                .orElse("DefaultNickname"); // 대체값을 제공하거나 예외를 던질 수 있음
+        // OAuth2UserInfo 객체 생성
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User);
 
-        String role = "ROLE_USER"; // 기본 사용자 역할
+        String email = userInfo.getEmail();
+        String nickname = userInfo.getNickname();
+        String role = "ROLE_USER";
 
         // JWT 토큰 생성
         String memberSpecification = String.format("%s:%s:%s", email, nickname, role);
         String accessToken = jwtTokenProvider.createAccessToken(memberSpecification);
-        log.info("accessToken :{}",accessToken);
+        log.info("accessToken :{}", accessToken);
 
-        // HTTP 응답 헤더에 토큰 추가
         response.addHeader("Authorization", "Bearer " + accessToken);
 
-        String targetUrl = String.format("http://localhost:3000/oauth/kakao/callback?token=%s", accessToken);
-        log.info("Redirecting to: {}", targetUrl);
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
-    }
+        // 리디렉트 URL 설정
+        String redirectUrl = OAuth2RedirectUrlProvider.getRedirectUrl(registrationId, accessToken);
 
-    @SuppressWarnings("unchecked")
-    private Optional<Map<String, Object>> safeCastToMap(Object obj) {
-        if (obj instanceof Map) {
-            return Optional.of((Map<String, Object>) obj);
-        }
-        return Optional.empty();
+        log.info("Redirecting to: {}", redirectUrl);
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 }

--- a/src/main/java/growup/spring/springserver/global/oauth/GoogleOAuth2UserInfo.java
+++ b/src/main/java/growup/spring/springserver/global/oauth/GoogleOAuth2UserInfo.java
@@ -1,0 +1,22 @@
+package growup.spring.springserver.global.oauth;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleOAuth2UserInfo(OAuth2User oAuth2User) {
+        this.attributes = oAuth2User.getAttributes();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+}

--- a/src/main/java/growup/spring/springserver/global/oauth/KakaoOAuth2UserInfo.java
+++ b/src/main/java/growup/spring/springserver/global/oauth/KakaoOAuth2UserInfo.java
@@ -1,0 +1,35 @@
+package growup.spring.springserver.global.oauth;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import java.util.Map;
+import java.util.Optional;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public KakaoOAuth2UserInfo(OAuth2User oAuth2User) {
+        this.attributes = oAuth2User.getAttributes();
+    }
+
+    @Override
+    public String getEmail() {
+        return safeCastToMap(attributes.get("kakao_account"))
+                .map(account -> (String) account.get("email"))
+                .orElseThrow(() -> new IllegalArgumentException("Kakao account data is missing"));
+    }
+
+    @Override
+    public String getNickname() {
+        return safeCastToMap(attributes.get("properties"))
+                .map(properties -> (String) properties.get("nickname"))
+                .orElse("DefaultNickname");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Map<String, Object>> safeCastToMap(Object obj) {
+        if (obj instanceof Map) {
+            return Optional.of((Map<String, Object>) obj);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/growup/spring/springserver/global/oauth/OAuth2RedirectUrlProvider.java
+++ b/src/main/java/growup/spring/springserver/global/oauth/OAuth2RedirectUrlProvider.java
@@ -1,0 +1,23 @@
+package growup.spring.springserver.global.oauth;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@UtilityClass
+public class OAuth2RedirectUrlProvider {
+    private static final Map<String, String> REDIRECT_URLS = new HashMap<>();
+
+    static {
+        REDIRECT_URLS.put("kakao", "http://localhost:3000/oauth/kakao/callback?token=%s");
+        REDIRECT_URLS.put("google", "http://localhost:3000/oauth/google/callback?token=%s");
+    }
+
+    public static String getRedirectUrl(String registrationId, String accessToken) {
+        if (!REDIRECT_URLS.containsKey(registrationId)) {
+            throw new IllegalArgumentException("지원하지 않는 OAuth 공급자: " + registrationId);
+        }
+        return String.format(REDIRECT_URLS.get(registrationId), accessToken);
+    }
+}

--- a/src/main/java/growup/spring/springserver/global/oauth/OAuth2UserInfo.java
+++ b/src/main/java/growup/spring/springserver/global/oauth/OAuth2UserInfo.java
@@ -1,0 +1,6 @@
+package growup.spring.springserver.global.oauth;
+
+public interface OAuth2UserInfo {
+    String getEmail();
+    String getNickname();
+}

--- a/src/main/java/growup/spring/springserver/global/oauth/OAuth2UserInfoFactory.java
+++ b/src/main/java/growup/spring/springserver/global/oauth/OAuth2UserInfoFactory.java
@@ -1,0 +1,21 @@
+package growup.spring.springserver.global.oauth;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@UtilityClass // 🔹 Lombok을 사용하여 인스턴스화 방지
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, OAuth2User oAuth2User) {
+        return switch (registrationId.toLowerCase()) {
+            case "kakao" -> new KakaoOAuth2UserInfo(oAuth2User);
+            case "google" -> new GoogleOAuth2UserInfo(oAuth2User);
+            default -> throw new IllegalArgumentException("Unsupported OAuth2 provider: " + registrationId);
+        };
+    }
+}
+
+// 유틸 클래스에서는 public 생성자가 없어야 합니다.
+// 유틸 클래스 만들 때는 private 생성자를 추가해 준다.
+
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -33,12 +33,26 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            client-name: google
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/google # 구글에 추가함
+            scope:
+              - profile
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
 logging:
   level:
     root: info


### PR DESCRIPTION
## 📝 Description
<!-- PR에 대한 설명을 작성해주세요 -->
기존에 있던 카카오 로그인만 있는 코드에서 확장성을 고려하여 짜보았습니다. 로컬은 됩니다.
yml 추가,  env 추가(노션에 추가), git Actions 키 추가 


### **1. 이메일과, 닉네임 얻기 인터페이스**
![스크린샷 2025-02-20 오전 12 13 00](https://github.com/user-attachments/assets/a8a38679-607a-4be3-9051-329bab9981fa)

### **2. 분기별 정보 가져오기**
1) 구글
![스크린샷 2025-02-20 오전 12 13 25](https://github.com/user-attachments/assets/d58dc53c-89ed-4589-94ec-673f1776b239)
2) 카카오
![스크린샷 2025-02-20 오전 12 13 34](https://github.com/user-attachments/assets/3ef24d67-c666-4745-8f0e-9ae3f9d2b0d9)


### **3. 분기별 callback 주소 가져오기**
![스크린샷 2025-02-20 오전 12 14 48](https://github.com/user-attachments/assets/43895dcd-639a-4127-a806-d7873ffa3425)

### **4. 팩토리 메서드 메서드 들어오는 것에 따라 UserInfo생성**

![스크린샷 2025-02-20 오전 12 15 43](https://github.com/user-attachments/assets/695e5b47-cd99-4ba8-9c7e-f8a36d22d013)

이에 따른 
OAuth2AuthenticationSuccessHandler, 
Oauth2UserService 클래스 수정

## 📌 Changes
<!-- 변경사항들을 리스트로 작성해주세요 -->
- 

## ✅ Check List
- [ ] 테스트 코드가 있다면 추가했나요?
- [ ] 새로운 의존성을 추가했다면 문서화했나요?
- [ ] 변경사항에 대한 테스트를 진행했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 📸 Screenshots
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
